### PR TITLE
Removed the closePoolExtension() line

### DIFF
--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -508,7 +508,6 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
      */
     function _cancelPool(uint256 _penalty) internal {
         poolVariables.loanStatus = LoanStatus.CANCELLED;
-        IExtension(IPoolFactory(poolFactory).extension()).closePoolExtension();
         _withdrawAllCollateral(poolConstants.borrower, _penalty);
         _pause();
         emit PoolCancelled();


### PR DESCRIPTION
As per previous discussions, I have removed the closePoolExtension line from the `_cancelPool()` function, as it would never be called.