### PR TITLE
Lime 69, Issue 5, Gas saving by duplicate check

### DIFF
--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -31,7 +31,6 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
      * @param _maxStrategies maximum number of strategies allowed
      **/
     function initialize(address _owner, uint256 _maxStrategies) external initializer {
-        require(_maxStrategies != 0, 'StrategyRegistry::initialize maxStrategies cannot be zero');
         __Ownable_init();
         super.transferOwnership(_owner);
 
@@ -44,11 +43,11 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
      * @param _maxStrategies updated number of max strategies allowed
      **/
     function updateMaxStrategies(uint256 _maxStrategies) external onlyOwner {
-        require(_maxStrategies != 0, 'StrategyRegistry::updateMaxStrategies should be more than zero');
         _updateMaxStrategies(_maxStrategies);
     }
 
     function _updateMaxStrategies(uint256 _maxStrategies) internal {
+        require(_maxStrategies != 0, 'StrategyRegistry::updateMaxStrategies should be more than zero');
         maxStrategies = _maxStrategies;
         emit MaxStrategiesUpdated(_maxStrategies);
     }

--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -44,11 +44,11 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
      * @param _maxStrategies updated number of max strategies allowed
      **/
     function updateMaxStrategies(uint256 _maxStrategies) external onlyOwner {
+        require(_maxStrategies != 0, 'StrategyRegistry::updateMaxStrategies should be more than zero');
         _updateMaxStrategies(_maxStrategies);
     }
 
     function _updateMaxStrategies(uint256 _maxStrategies) internal {
-        require(_maxStrategies != 0, 'StrategyRegistry::updateMaxStrategies should be more than zero');
         maxStrategies = _maxStrategies;
         emit MaxStrategiesUpdated(_maxStrategies);
     }


### PR DESCRIPTION
## Description

`maxStrategies` check needs to be added to `updateMaxStrategies` instead of `_updateMaxStrategies`, to save gas by decreasing the code size. 

PR to fix issue listed at: https://github.com/code-423n4/2021-12-sublime-findings/issues/5

## Integration Checklist

- [ ] Compare gas savings from gasReport.md

## Changelog

Removed duplicate checks for *_maxStrategies* and optimized gas usage.



