### PR TITLE
LIME 70, Issue 6, Removed safemath for gas optimization

### DIFF
--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -66,7 +66,7 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
      * @param _strategy address of the strategy contract
      **/
     function addStrategy(address _strategy) external override onlyOwner {
-        require(strategies.length.add(1) <= maxStrategies, "StrategyRegistry::addStrategy - Can't add more strategies");
+        require(strategies.length + 1 <= maxStrategies, "StrategyRegistry::addStrategy - Can't add more strategies");
         require(!registry[_strategy], 'StrategyRegistry::addStrategy - Strategy already exists');
         require(_strategy != address(0), 'StrategyRegistry::addStrategy - _strategy cannot be address(0)');
         registry[_strategy] = true;


### PR DESCRIPTION
## Description
Before Solidity 0.8.0, SafeMaths had to be used in smart contracts to check for over/under flow while doing calculations. Removing SafeMath operations from places where over/under flow is not possible, would save gas.

PR opened to fix issue mentioned at: https://github.com/code-423n4/2021-12-sublime-findings/issues/6

## Integrations Checklist
- [ ] Compare gas savings from gasReport.md

## Change Log
Removed safemath from a suitable `require` statment of method addStrategy inside StrategyRegistry, to save gas.