### PR TITLE
Lime 73, Issue 22, Switched to pre increments

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -481,7 +481,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         ISavingsAccount _savingsAccount = ISavingsAccount(savingsAccount);
         uint256 _activeAmount;
 
-        for (uint256 _index = 0; _index < _strategyList.length; _index++) {
+        for (uint256 _index = 0; _index < _strategyList.length; ++_index) {
             address _strategy = _strategyList[_index];
             uint256 _liquidityShares = _savingsAccount.balanceInShares(_sender, _collateralAsset, _strategy);
             if (_liquidityShares == 0 || _strategyList[_index] == address(0)) {
@@ -659,7 +659,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         address[] memory _strategyList = IStrategyRegistry(strategyRegistry).getStrategies();
         ISavingsAccount _savingsAccount = ISavingsAccount(savingsAccount);
         uint256 _activeAmount;
-        for (uint256 _index = 0; _index < _strategyList.length; _index++) {
+        for (uint256 _index = 0; _index < _strategyList.length; ++_index) {
             if (_strategyList[_index] == address(0)) {
                 continue;
             }
@@ -735,7 +735,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         ISavingsAccount _savingsAccount = ISavingsAccount(savingsAccount);
         uint256 _activeAmount;
 
-        for (uint256 _index = 0; _index < _strategyList.length; _index++) {
+        for (uint256 _index = 0; _index < _strategyList.length; ++_index) {
             if (_strategyList[_index] == address(0)) {
                 continue;
             }
@@ -889,7 +889,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         address _collateralAsset = creditLineConstants[_id].collateralAsset;
         address[] memory _strategyList = IStrategyRegistry(strategyRegistry).getStrategies();
         uint256 _liquidityShares;
-        for (uint256 index = 0; index < _strategyList.length; index++) {
+        for (uint256 index = 0; index < _strategyList.length; ++index) {
             if (_strategyList[index] == address(0)) {
                 continue;
             }
@@ -956,7 +956,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
     ) internal {
         address[] memory _strategyList = IStrategyRegistry(strategyRegistry).getStrategies();
         uint256 _activeAmount;
-        for (uint256 index = 0; index < _strategyList.length; index++) {
+        for (uint256 index = 0; index < _strategyList.length; ++index) {
             uint256 liquidityShares = collateralShareInStrategy[_id][_strategyList[index]];
             if (liquidityShares == 0 || _strategyList[index] == address(0)) {
                 continue;

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -286,7 +286,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
     function withdrawAll(address _token) external override nonReentrant returns (uint256 _tokenReceived) {
         address[] memory _strategyList = IStrategyRegistry(strategyRegistry).getStrategies();
 
-        for (uint256 i = 0; i < _strategyList.length; i++) {
+        for (uint256 i = 0; i < _strategyList.length; ++i) {
             if (balanceInShares[msg.sender][_token][_strategyList[i]] != 0 && _strategyList[i] != address(0)) {
                 uint256 _amount = balanceInShares[msg.sender][_token][_strategyList[i]];
                 _amount = IYield(_strategyList[i]).unlockTokens(_token, balanceInShares[msg.sender][_token][_strategyList[i]]);
@@ -464,7 +464,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
     function getTotalTokens(address _user, address _token) external override returns (uint256 _totalTokens) {
         address[] memory _strategyList = IStrategyRegistry(strategyRegistry).getStrategies();
 
-        for (uint256 i = 0; i < _strategyList.length; i++) {
+        for (uint256 i = 0; i < _strategyList.length; ++i) {
             uint256 _liquidityShares = balanceInShares[_user][_token][_strategyList[i]];
 
             if (_liquidityShares != 0) {


### PR DESCRIPTION
## Description
Replacing post-increments with pre-increments can save gas as they are cheaper.
No need to add unchecked with the pre-increments as it is a behaviour introduced after Solidity 0.8.0

PR opened to fix issue mentioned at: https://github.com/code-423n4/2021-12-sublime-findings/issues/22

## Integrations Checklist
- [ ] Compare gas savings from gasReport.md

## Change Log
Post-increments were replaced with pre-increments throughout the contracts to save on gas costs.