### PR TITLE
LIME 87, Issue 66, Removed unnecessary checks

### DIFF
--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -791,7 +791,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
      * @param _lender address of the lender to be liquidated
      */
     function _canLenderBeLiquidated(address _lender) internal {
-        require((poolVariables.loanStatus == LoanStatus.ACTIVE) && (block.timestamp > poolConstants.loanWithdrawalDeadline), 'CLBL1');
+        require(poolVariables.loanStatus == LoanStatus.ACTIVE, 'CLBL1');
         uint256 _marginCallEndTime = lenders[_lender].marginCallEndTime;
         require(getMarginCallEndTime(_lender) != 0, 'CLBL2');
         require(_marginCallEndTime < block.timestamp, 'CLBL3');


### PR DESCRIPTION
## Description
In Pool.withdrawBorrowedAmount we set the loan to active and delete the withdrawal deadline. When checking whether we can liquidate the pool we check that the loan is active and that block.timestamp > poolConstants.loanWithdrawalDeadline. This second condition always resolves true as poolConstants.loanWithdrawalDeadline = 0 after deletion. We can then save an SLOAD by skipping this second check.

PR opened to fix issue at: https://github.com/code-423n4/2021-12-sublime-findings/issues/66

## Integration Checklist

- [ ]  Compare gas cost optimisation from gasReport.md

## Change Log
Unnecessary conditions were removed from require statement.  