### PR TITLE
Lime 101, Issue 90, ETH asset added for liquidation

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -1014,6 +1014,10 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
             uint256 _borrowTokens = _borrowTokensToLiquidate(_borrowAsset, _collateralAsset, _totalCollateralTokens);
             if (_borrowAsset == address(0)) {
                 uint256 _returnETH = msg.value.sub(_borrowTokens, 'Insufficient ETH to liquidate');
+                
+                (bool success, ) = _lender.call{value: _borrowTokens}('');
+		        require(success, 'liquidate: Transfer failed');
+                
                 if (_returnETH != 0) {
                     (bool success, ) = msg.sender.call{value: _returnETH}('');
                     require(success, 'Transfer fail');

--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -1014,10 +1014,8 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
             uint256 _borrowTokens = _borrowTokensToLiquidate(_borrowAsset, _collateralAsset, _totalCollateralTokens);
             if (_borrowAsset == address(0)) {
                 uint256 _returnETH = msg.value.sub(_borrowTokens, 'Insufficient ETH to liquidate');
-                
                 (bool success, ) = _lender.call{value: _borrowTokens}('');
 		        require(success, 'liquidate: Transfer failed');
-                
                 if (_returnETH != 0) {
                     (bool success, ) = msg.sender.call{value: _returnETH}('');
                     require(success, 'Transfer fail');

--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -1014,8 +1014,11 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
             uint256 _borrowTokens = _borrowTokensToLiquidate(_borrowAsset, _collateralAsset, _totalCollateralTokens);
             if (_borrowAsset == address(0)) {
                 uint256 _returnETH = msg.value.sub(_borrowTokens, 'Insufficient ETH to liquidate');
+
                 (bool success, ) = _lender.call{value: _borrowTokens}('');
-		        require(success, 'liquidate: Transfer failed');
+		        
+                require(success, 'liquidate: Transfer failed');
+                
                 if (_returnETH != 0) {
                     (bool success, ) = msg.sender.call{value: _returnETH}('');
                     require(success, 'Transfer fail');


### PR DESCRIPTION
## Description

Funds that are acquired from a liquidator and should be sent to a lender are left with the contract instead. The funds aren't lost, but after the fact mitigation will require manual accounting and fund transfer for each CreditLine.liquidate usage.

PR opened to fix issue at: https://github.com/code-423n4/2021-12-sublime-findings/issues/90

## Integration Checklist

- [ ] Write tests to check credit line liquidation with ETH as the borrow asset.

## Change Log

The case of ETH being used as borrow asset in credit lines was always there, but was missed in the `Creditline.liquidate` function. It has now been added. 