### PR TITLE
Lime-104, Issue 96: credit line liquidation

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -1003,8 +1003,10 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
             'CreditLine: Collateral ratio is higher than ideal value'
         );
 
-        address _collateralAsset = creditLineConstants[_id].collateralAsset;
         address _lender = creditLineConstants[_id].lender;
+        require(creditLineConstants[_id].autoLiquidation || msg.sender == _lender, 'CreditLine: Only Lender can liquidate if autoLiquidation is false');
+
+        address _collateralAsset = creditLineConstants[_id].collateralAsset;
         uint256 _totalCollateralTokens = calculateTotalCollateralTokens(_id);
         address _borrowAsset = creditLineConstants[_id].borrowAsset;
 


### PR DESCRIPTION
# Description
Stacked pull request on #173
It is intended that if a credit line has autoLiquidation as false, then only the lender can be the liquidator (see docs here: https://docs.sublime.finance/sublime-docs/smart-contracts/creditlines). However, this is not correctly implemented, and anyone can liquidate a position that has autoLiquidation set to false.

Even worse, when autoLiquidation is set to false, the liquidator does not have to supply the initial amount of borrow tokens (determined by _borrowTokensToLiquidate) that normally have to be transferred when autoLiquidation is true. This means that the liquidator will be sent all of the collateral that is supposed to be sent to the lender, so this represents a huge loss to the lender. Since the lender will lose all of the collateral that they are owed, this is a high severity issue.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Added a require statement to the liquidate function in the `CreditLine.sol` contract(Issue 96: credit line liquidation
Ref: https://github.com/code-423n4/2021-12-sublime-findings/issues/96)

# Event Signature Changes

# Function Signature Changes

# Features

# Events
