### PR TITLE
Lime 105, Issue 99, Removed unnecessary receive function

### DIFF
--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -476,6 +476,4 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
             }
         }
     }
-
-    receive() external payable {}
 }


### PR DESCRIPTION
## Description:

A `recieve()` function had been left in the Sublime smart contracts, which wasn't really required as we have separate dedicated functions for transactions of tokens. Worse of all, if someone accidently sent native tokens to the contracts, then there would be no way retrieve it.

PR opened to fix issue at: https://github.com/code-423n4/2021-12-sublime-findings/issues/99

## Integration Checklist

- [ ] Write tests checking that native token transfer to Sublime contracts should fail.

## Change Log
Native token transfers to the Sublime smart contracts cannot take place now.