### PR TITLE
Lime 106, Issue 102, Implemented msg.sender inplace of _msgSender()

### DIFF
--- a/contracts/yield/AaveYield.sol
+++ b/contracts/yield/AaveYield.sol
@@ -68,7 +68,7 @@ contract AaveYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard
      * @notice verifies if savings account invoked the contract
      */
     modifier onlySavingsAccount() {
-        require(_msgSender() == savingsAccount, 'Invest: Only savings account can invoke');
+        require(msg.sender == savingsAccount, 'Invest: Only savings account can invoke');
         _;
     }
 

--- a/contracts/yield/CompoundYield.sol
+++ b/contracts/yield/CompoundYield.sol
@@ -40,7 +40,7 @@ contract CompoundYield is IYield, Initializable, OwnableUpgradeable, ReentrancyG
      * @notice checks if contract is invoked by savings account
      **/
     modifier onlySavingsAccount() {
-        require(_msgSender() == savingsAccount, 'Invest: Only savings account can invoke');
+        require(msg.sender == savingsAccount, 'Invest: Only savings account can invoke');
         _;
     }
 

--- a/contracts/yield/NoYield.sol
+++ b/contracts/yield/NoYield.sol
@@ -28,7 +28,7 @@ contract NoYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard {
      * @notice checks if contract is invoked by savings account
      **/
     modifier onlySavingsAccount() {
-        require(_msgSender() == savingsAccount, 'Invest: Only savings account can invoke');
+        require(msg.sender == savingsAccount, 'Invest: Only savings account can invoke');
         _;
     }
 

--- a/contracts/yield/YearnYield.sol
+++ b/contracts/yield/YearnYield.sol
@@ -39,7 +39,7 @@ contract YearnYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuar
      * @notice checks if contract is invoked by savings account
      **/
     modifier onlySavingsAccount() {
-        require(_msgSender() == savingsAccount, 'Invest: Only savings account can invoke');
+        require(msg.sender == savingsAccount, 'Invest: Only savings account can invoke');
         _;
     }
 


### PR DESCRIPTION
## Description

The use of _msgSender() when there is no implementation of a meta transaction mechanism that uses it, such as EIP-2771, slightly increases gas consumption.

PR opened for issue at: https://github.com/code-423n4/2021-12-sublime-findings/issues/102

## Integration Checklist

- [ ] Compare change in gas consumption using gasReport.md

## Change Log

Use of `_msgSender` replaced with `msg.sender` to save gas costs.