### PR TITLE
Lime 111, Issue 112, Gas opt in credit-lines

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -393,9 +393,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         uint256 _borrowRate,
         uint256 _timeElapsed
     ) public pure returns (uint256) {
-        uint256 _interest = _principal.mul(_borrowRate).mul(_timeElapsed).div(10**30).div(YEAR_IN_SECONDS);
-
-        return _interest;
+        return (_principal.mul(_borrowRate).mul(_timeElapsed).div(10**30).div(YEAR_IN_SECONDS));
     }
 
     /**
@@ -690,11 +688,10 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
      */
     function borrow(uint256 _id, uint256 _amount) external payable nonReentrant onlyCreditLineBorrower(_id) {
         require(creditLineVariables[_id].status == CreditLineStatus.ACTIVE, 'CreditLine: The credit line is not yet active.');
-        uint256 _borrowableAmount = calculateBorrowableAmount(_id);
-        require(_amount <= _borrowableAmount, "CreditLine::borrow - The current collateral ratio doesn't allow to withdraw the amount");
+        require(_amount <= calculateBorrowableAmount(_id), "CreditLine::borrow - The current collateral ratio doesn't allow to withdraw the amount");
         address _borrowAsset = creditLineConstants[_id].borrowAsset;
         address _lender = creditLineConstants[_id].lender;
-
+        
         updateinterestAccruedTillLastPrincipalUpdate(_id);
         creditLineVariables[_id].principal = creditLineVariables[_id].principal.add(_amount);
         creditLineVariables[_id].lastPrincipalUpdateTime = block.timestamp;


### PR DESCRIPTION
## Description

Unnecessary declared variables can be removed to make the code more clean, easy-to-understand and more importantly to save gas.

PR opened to fix issue at: https://github.com/code-423n4/2021-12-sublime-findings/issues/112

## Integration Checklist

- [ ] Compare gas optimization using gasReport.md

## Change Log
Unnecessary variables removal can lead to optimized gas consumption.