### PR TITLE
Lime 119, Issue 135, Fix unclear comment

### DIFF
--- a/contracts/yield/AaveYield.sol
+++ b/contracts/yield/AaveYield.sol
@@ -210,7 +210,7 @@ contract AaveYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard
 
     /**
      * @notice Used to unlock tokens from available protocol
-     * @param asset the address of underlying token
+     * @param asset the address of share token
      * @param amount the amount of asset
      * @return received amount of tokens received
      **/

--- a/contracts/yield/CompoundYield.sol
+++ b/contracts/yield/CompoundYield.sol
@@ -131,7 +131,7 @@ contract CompoundYield is IYield, Initializable, OwnableUpgradeable, ReentrancyG
 
     /**
      * @notice Used to unlock tokens from available protocol
-     * @param asset the address of underlying token
+     * @param asset the address of share token
      * @param amount the amount of asset
      * @return received amount of tokens received
      **/

--- a/contracts/yield/NoYield.sol
+++ b/contracts/yield/NoYield.sol
@@ -107,7 +107,7 @@ contract NoYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard {
 
     /**
      * @notice Used to unlock tokens from the protocol
-     * @param asset the address of underlying token
+     * @param asset the address of share token
      * @param amount the amount of asset
      * @return tokensReceived received amount of tokens received
      **/

--- a/contracts/yield/YearnYield.sol
+++ b/contracts/yield/YearnYield.sol
@@ -132,7 +132,7 @@ contract YearnYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuar
 
     /**
      * @notice Used to unlock tokens from available protocol
-     * @param asset the address of underlying token
+     * @param asset the address of share token
      * @param amount the amount of asset
      * @return received amount of tokens received
      **/


### PR DESCRIPTION
## Description
The current natspec comment for the `unlockShares` function was a little ambiguos. It has to be fixed.

PR opened to fix issue: https://github.com/code-423n4/2021-12-sublime-findings/issues/135

## Change Log
The natspec documentation of a function was improved.