### PR TITLE
caching storage variables in SavingsAccount.sol

### DIFF
--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -159,14 +159,15 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         require(IStrategyRegistry(strategyRegistry).registry(_newStrategy), 'SavingsAccount::_newStrategy do not exist');
         require(_amount != 0, 'SavingsAccount::switchStrategy Amount must be greater than zero');
 
-        _amount = IYield(_currentStrategy).getSharesForTokens(_amount, _token);
+        IYield currentStrategy = IYield(_currentStrategy);
+        _amount = currentStrategy.getSharesForTokens(_amount, _token);
 
         balanceInShares[msg.sender][_token][_currentStrategy] = balanceInShares[msg.sender][_token][_currentStrategy].sub(
             _amount,
             'SavingsAccount::switchStrategy Insufficient balance'
         );
 
-        uint256 _tokensReceived = IYield(_currentStrategy).unlockTokens(_token, _amount);
+        uint256 _tokensReceived = currentStrategy.unlockTokens(_token, _amount);
 
         uint256 _ethValue;
         if (_token != address(0)) {
@@ -256,9 +257,10 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         bool _withdrawShares
     ) internal returns (address _tokenReceived, uint256 _amountReceived) {
         if (_withdrawShares) {
-            _tokenReceived = IYield(_strategy).liquidityToken(_token);
+            IYield strategy = IYield(_strategy);
+            _tokenReceived = strategy.liquidityToken(_token);
             require(_tokenReceived != address(0), 'Liquidity Tokens address cannot be address(0)');
-            _amountReceived = IYield(_strategy).unlockShares(_tokenReceived, _amount);
+            _amountReceived = strategy.unlockShares(_tokenReceived, _amount);
         } else {
             _tokenReceived = _token;
             _amountReceived = IYield(_strategy).unlockTokens(_token, _amount);


### PR DESCRIPTION
# Description
Stacked on PR #189 
Issue 117: Cache storage variables in the stack can save gas
Ref: https://github.com/code-423n4/2021-12-sublime-findings/issues/117
The whole code base was checked for the mentioned issue and was fixed for all instances observed.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- caching storage variables in SavingsAccount.sol(Issue 117: Cache storage variables in the stack can save gas
Ref: https://github.com/code-423n4/2021-12-sublime-findings/issues/117)

# Event Signature Changes

# Function Signature Changes

# Features

# Events



Caching storage variables in the rest of the codebase.