### PR TITLE
Lime-124, Issue 146 - Fix Self-transfer leads to wrong withdrawable repayments

### DIFF
--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -429,6 +429,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         if (_to != address(0)) {
             require(!paused(), 'TT1');
         }
+        require(_from != _to, 'TT6');
         require(_to != poolConstants.borrower, 'TT2');
 
         if (_from == address(0) || _to == address(0)) {


### PR DESCRIPTION
Self transfer would lead to would lead to wrong calculation of `effectiveInterestWithdrawn`

When transferring pool tokens to oneself the Pool._beforeTokenTransfer overwrites the effectiveInterestWithdrawn of the user with a higher amount than expected.
It uses the previous balance + the transfer amount instead of just the previous balance:
```
// @audit if from == to: overwrites with last _to statement => bug
lenders[_from].effectiveInterestWithdrawn = (_fromBalance.sub(_amount)).mul(_totalRepaidAmount).div(_totalSupply);
lenders[_to].effectiveInterestWithdrawn = (_toBalance.add(_amount)).mul(_totalRepaidAmount).div(_totalSupply);
```

PR to fix issue https://github.com/code-423n4/2021-12-sublime-findings/issues/146

# Integrations Checklist

- [ ] Tests to be added to verify the balance updates
- [ ] New error code `TT6` to be added to documentation

# Change Log

- Self transfer where `from == to` is not allowed to ensure that any complications due to this case are avoided. There is also no specific use case for self transfer.