### PR TITLE
Lime 222, CS Audit

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -128,15 +128,6 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
     }
 
     /**
-     * @dev checks if called by credit Line Lender
-     * @param _id creditLine identifier
-     **/
-    modifier onlyCreditLineLender(uint256 _id) {
-        require(creditLineConstants[_id].lender == msg.sender, 'Only credit line Lender can access');
-        _;
-    }
-
-    /**
      * @notice emitted when a collateral is deposited into credit line
      * @param id id of the credit line
      * @param amount amount of collateral deposited


### PR DESCRIPTION
## Description

Removed the `onlyCreditLineLender` modifier as it was declared, but never used. So, removing it can lead to gas saving.

## Integration Checklist

- [ ] Run existing tests and make sure no tests break
- [ ] Compare gas savings using gasReport.md

## Change Log
An unused modifier was removed from Credit Lines