### PR TITLE
CS Audit, Lime 192, Added Sanity checks on share transfer

### DIFF
--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -270,6 +270,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _token,
         address payable _to
     ) internal {
+        require(_to != address(0), 'The to address should be a valid address');
         if (_token == address(0)) {
             (bool _success, ) = _to.call{value: _amount}('');
             require(_success, 'Transfer failed');


### PR DESCRIPTION
## Description

The function transfer does not perform sanity checks for the parameter _to. Hence, it is possible to send to address zero and effectively "burn" the shares from the saving strategies during transfer.

## Integration Checklist

- [ ] Add tests which check calling the transfer function with _to address set as 0.

## Change Log

Sanity check was added to `SavingsAccount.transfer` function.
