### PR TITLE
CS Audit, Lime 181, Stacked requires together

### DIFF
--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -112,6 +112,9 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _to
     ) external payable override nonReentrant returns (uint256) {
         require(_to != address(0), 'SavingsAccount::deposit receiver address should not be zero address');
+        require(_amount != 0, 'SavingsAccount::deposit Amount must be greater than zero');
+        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::deposit strategy do not exist');
+        
         uint256 _sharesReceived = _deposit(_amount, _token, _strategy);
         balanceInShares[_to][_token][_strategy] = balanceInShares[_to][_token][_strategy].add(_sharesReceived);
         emit Deposited(_to, _sharesReceived, _token, _strategy);
@@ -123,7 +126,6 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _token,
         address _strategy
     ) internal returns (uint256 _sharesReceived) {
-        require(_amount != 0, 'SavingsAccount::_deposit Amount must be greater than zero');
         _sharesReceived = _depositToYield(_amount, _token, _strategy);
     }
 
@@ -132,7 +134,6 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _token,
         address _strategy
     ) internal returns (uint256 _sharesReceived) {
-        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::deposit strategy do not exist');
         uint256 _ethValue;
 
         if (_token == address(0)) {


### PR DESCRIPTION
## Description

The following function in SavingsAccount 

deposit(uint256 _amount, address _token, address _strategy, address _to) 

does a single sanity check for the _to parameter, then calls the internal function _deposit which does another sanity check for the amount parameter. Next, function _depositToYield is called which does another sanity check for the initial parameter _strategy. 

It is a good practice to do all such checks first in the initial function when possible, e.g., deposit, instead of splitting them among multiple functions. Other examples: 

• require(_lender != _borrower) in _createRequest. 

• require(creditLineConstants[_id].lender != msg.sender) in _depositCollateral.

## Integration Checklist

- [ ] The existing tests shouldn't break

## Change Log

Different require statements were stacked together in the SavingsAccount.sol smart contract.