### PR TITLE
CS Audit, Lime 220, Removed unused enum state

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -26,7 +26,6 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         REQUESTED,
         ACTIVE,
         CLOSED,
-        CANCELLED,
         LIQUIDATED
     }
 


### PR DESCRIPTION
## Description

In CreditLine the CreditLineStatus has the definition CANCELLED. This definition is never used and therefore can be removed.

## Integration Checklist

- [ ] Make sure all existing tests should pass
- [ ] Gas costs reduction can be compared using gasReport.md

## Changelog

An unused enum state was removed from CreditLines.