### PR TITLE
CS Audit, Lime 191, Renamed poolFactory modifier

### DIFF
--- a/contracts/Pool/PoolFactory.sol
+++ b/contracts/Pool/PoolFactory.sol
@@ -153,12 +153,12 @@ contract PoolFactory is Initializable, OwnableUpgradeable, IPoolFactory {
     }
 
     /**
-     * @notice functions affected by this modifier can only be invoked by the borrow of the Pool
+     * @notice functions affected by this modifier can only be invoked by the borrower (verified user) of the Pool
      */
-    modifier onlyBorrower(address _verifier) {
+    modifier onlyVerified(address _verifier) {
         require(
             IVerification(userRegistry).isUser(msg.sender, _verifier),
-            'PoolFactory::onlyBorrower - Only a valid Borrower can create Pool'
+            'PoolFactory::onlyVerified - Only a valid Borrower can create Pool'
         );
         _;
     }
@@ -271,7 +271,7 @@ contract PoolFactory is Initializable, OwnableUpgradeable, IPoolFactory {
         bytes32 _salt,
         address _verifier,
         address _lenderVerifier
-    ) external payable onlyBorrower(_verifier) {
+    ) external payable onlyVerified(_verifier) {
         if (_collateralToken == address(0)) {
             require(msg.value == _collateralAmount, 'PoolFactory::createPool - Ether send is different from collateral amount specified');
         }

--- a/contracts/Pool/PoolFactory.sol
+++ b/contracts/Pool/PoolFactory.sol
@@ -153,7 +153,7 @@ contract PoolFactory is Initializable, OwnableUpgradeable, IPoolFactory {
     }
 
     /**
-     * @notice functions affected by this modifier can only be invoked by the borrower (verified user) of the Pool
+     * @notice functions affected by this modifier can only be invoked by a verified user of Sublime
      */
     modifier onlyVerified(address _verifier) {
         require(


### PR DESCRIPTION
## Description

The PoolFactory contract implements a modifier as shown below: 

modifier onlyBorrower(address _verifier) { require( IVerification(userRegistry).isUser(msg.sender, _verifier), 'PoolFactory::onlyBorrower - Only a valid Borrower can create Pool' ); _; } 

The name onlyBorrower implies that only a borrower of a pool can call functions protected by this modifier, however, the modifier only checks that the msg.sender has been verified by _verifier and not if it is a borrower of a pool.

## Integration Checklist

- [ ] The exisiting tests should not break.

## Change Log

The name of the `onlyBorrower` modifier in PoolFactory.sol has been changed to a more appropriate `onlyVerified`.