### PR TITLE
CS Audit, Lime 181, Stacked requires together

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -536,7 +536,6 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
     ) external returns (uint256) {
         require(_borrowAsset != _collateralAsset, 'R: cant borrow lent token');
         require(IPriceOracle(priceOracle).doesFeedExist(_borrowAsset, _collateralAsset), 'R: No price feed');
-        require(_lender != _borrower, 'Lender and Borrower cannot be same addresses');
 
         address _lender = _requestTo;
         address _borrower = msg.sender;
@@ -544,6 +543,8 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
             _lender = msg.sender;
             _borrower = _requestTo;
         }
+
+        require(_lender != _borrower, 'Lender and Borrower cannot be same addresses');
 
         uint256 _id = _createRequest(
             _lender,

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -158,6 +158,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
     ) external override nonReentrant {
         require(_currentStrategy != _newStrategy, 'SavingsAccount::switchStrategy Same strategy');
         require(_amount != 0, 'SavingsAccount::switchStrategy Amount must be greater than zero');
+        require(IStrategyRegistry(strategyRegistry).registry(_newStrategy), 'SavingsAccount::deposit strategy do not exist');
 
         _amount = IYield(_currentStrategy).getSharesForTokens(_amount, _token);
 

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -123,7 +123,6 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _token,
         address _strategy
     ) internal returns (uint256 _sharesReceived) {
-        require(_amount != 0, 'SavingsAccount::_deposit Amount must be greater than zero');
         _sharesReceived = _depositToYield(_amount, _token, _strategy);
     }
 
@@ -132,7 +131,6 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _token,
         address _strategy
     ) internal returns (uint256 _sharesReceived) {
-        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::deposit strategy do not exist');
         uint256 _ethValue;
 
         if (_token == address(0)) {
@@ -157,6 +155,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
     ) external override nonReentrant {
         require(_currentStrategy != _newStrategy, 'SavingsAccount::switchStrategy Same strategy');
         require(_amount != 0, 'SavingsAccount::switchStrategy Amount must be greater than zero');
+        require(IStrategyRegistry(strategyRegistry).registry(_newStrategy), 'SavingsAccount::deposit strategy do not exist');
 
         _amount = IYield(_currentStrategy).getSharesForTokens(_amount, _token);
 

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -112,6 +112,9 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _to
     ) external payable override nonReentrant returns (uint256) {
         require(_to != address(0), 'SavingsAccount::deposit receiver address should not be zero address');
+        require(_amount != 0, 'SavingsAccount::_deposit Amount must be greater than zero');
+        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::deposit strategy do not exist');
+
         uint256 _sharesReceived = _deposit(_amount, _token, _strategy);
         balanceInShares[_to][_token][_strategy] = balanceInShares[_to][_token][_strategy].add(_sharesReceived);
         emit Deposited(_to, _amount, _token, _strategy);
@@ -155,7 +158,6 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
     ) external override nonReentrant {
         require(_currentStrategy != _newStrategy, 'SavingsAccount::switchStrategy Same strategy');
         require(_amount != 0, 'SavingsAccount::switchStrategy Amount must be greater than zero');
-        require(IStrategyRegistry(strategyRegistry).registry(_newStrategy), 'SavingsAccount::deposit strategy do not exist');
 
         _amount = IYield(_currentStrategy).getSharesForTokens(_amount, _token);
 


### PR DESCRIPTION
## Description

The following function in SavingsAccount 

deposit(uint256 _amount, address _token, address _strategy, address _to) 

does a single sanity check for the _to parameter, then calls the internal function _deposit which does another sanity check for the amount parameter. Next, function _depositToYield is called which does another sanity check for the initial parameter _strategy. 

It is a good practice to do all such checks first in the initial function when possible, e.g., deposit, instead of splitting them among multiple functions. Other examples: 

• require(_lender != _borrower) in _createRequest. 

• require(creditLineConstants[_id].lender != msg.sender) in _depositCollateral.

## Integration Checklist

- [ ] The existing tests shouldn't break

## Change Log

Different require statements were stacked together in the SavingsAccount.sol smart contract.