### PR TITLE
CS Audit, Lime 218, Added checks for strategy addresses

### DIFF
--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -420,8 +420,8 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _to
     ) external override returns (uint256) {
         require(_amount != 0, 'SavingsAccount::transferFrom zero amount');
-        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::deposit strategy do not exist');
-        require(_to != address(0), "SavingsAccount:transferFrom _to should be a non-zero address");
+        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::transferFrom strategy do not exist');
+        
         //update allowance
         allowance[_from][_token][msg.sender] = allowance[_from][_token][msg.sender].sub(
             _amount,

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -384,6 +384,8 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _to
     ) external override returns (uint256) {
         require(_amount != 0, 'SavingsAccount::transfer zero amount');
+        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::transfer strategy do not exist');
+        require(_to != address(0), "SavingsAccount:transfer _to should be a non-zero address");
 
         if (_strategy != address(0)) {
             _amount = IYield(_strategy).getSharesForTokens(_amount, _token);
@@ -418,6 +420,8 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         address _to
     ) external override returns (uint256) {
         require(_amount != 0, 'SavingsAccount::transferFrom zero amount');
+        require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::deposit strategy do not exist');
+        require(_to != address(0), "SavingsAccount:transferFrom _to should be a non-zero address");
         //update allowance
         allowance[_from][_token][msg.sender] = allowance[_from][_token][msg.sender].sub(
             _amount,

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -385,7 +385,6 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
     ) external override returns (uint256) {
         require(_amount != 0, 'SavingsAccount::transfer zero amount');
         require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::transfer strategy do not exist');
-        require(_to != address(0), "SavingsAccount:transfer _to should be a non-zero address");
 
         if (_strategy != address(0)) {
             _amount = IYield(_strategy).getSharesForTokens(_amount, _token);


### PR DESCRIPTION
## Description

There are multiple calls to the strategy contract. But the user is allowed to pass in the strategy. Hence, it remains unclear if a whitelisted strategy or a malicious contract is called. We could not find any severe impact but e.g., in transfer and transferFrom in the SavingsAccount contract, the strategy contract is called without being checked if it is a valid strategy.

## Integration Checklist

- [ ] Write tests that check passing of unsanitized strategy addresses

## Change Log

Sanity checks were added to check the address of strategy addresses in `transfer` and `transferFrom` function in `SavingsAccount.sol`.