### PR TITLE
CS Audit, Lime 206, Gas opt in creditline closure

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -872,6 +872,8 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         require(creditLineVariables[_id].principal == 0, 'CreditLine: Cannot be closed since not repaid.');
         require(creditLineVariables[_id].interestAccruedTillLastPrincipalUpdate == 0, 'CreditLine: Cannot be closed since not repaid.');
         creditLineVariables[_id].status = CreditLineStatus.CLOSED;
+        delete creditLineConstants[_id];
+        delete creditLineVariables[_id];
         emit CreditLineClosed(_id);
     }
 

--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -888,7 +888,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
     function cancel(uint256 _id) external ifCreditLineExists(_id) {
         require(
             msg.sender == creditLineConstants[_id].borrower || msg.sender == creditLineConstants[_id].lender,
-            'CreditLine: Permission denied while closing Line of credit'
+            'CreditLine: Permission denied while cancelling CreditLine'
         );
         require(creditLineVariables[_id].status == CreditLineStatus.REQUESTED, 'CreditLine:cancle Credit Line should be in requested state');
         delete creditLineVariables[_id];

--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -25,7 +25,6 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         NOT_CREATED,
         REQUESTED,
         ACTIVE,
-        CLOSED,
         CANCELLED,
         LIQUIDATED
     }
@@ -199,6 +198,12 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
      * @param repayAmount amount repaid
      */
     event CompleteCreditLineRepaid(uint256 indexed id, uint256 repayAmount);
+
+    /**
+     * @notice emitted when credit line is cancelled
+     * @param id id of the credit line that was cancelled
+     */
+    event CreditLineCancelled(uint256 indexed id);
 
     /**
      * @notice emitted when the credit line is closed by one of the parties of credit line
@@ -871,10 +876,24 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         require(creditLineVariables[_id].status == CreditLineStatus.ACTIVE, 'CreditLine: Credit line should be active.');
         require(creditLineVariables[_id].principal == 0, 'CreditLine: Cannot be closed since not repaid.');
         require(creditLineVariables[_id].interestAccruedTillLastPrincipalUpdate == 0, 'CreditLine: Cannot be closed since not repaid.');
-        creditLineVariables[_id].status = CreditLineStatus.CLOSED;
         delete creditLineConstants[_id];
         delete creditLineVariables[_id];
         emit CreditLineClosed(_id);
+    }
+
+    /**
+     * @dev used to cancel credit line by borrower or lender
+     * @param _id identifier for the credit line
+    */
+    function cancel(uint256 _id) external ifCreditLineExists(_id) {
+        require(
+            msg.sender == creditLineConstants[_id].borrower || msg.sender == creditLineConstants[_id].lender,
+            'CreditLine: Permission denied while closing Line of credit'
+        );
+        require(creditLineVariables[_id].status == CreditLineStatus.REQUESTED, 'CreditLine:cancle Credit Line should be in requested state');
+        delete creditLineVariables[_id];
+        delete creditLineConstants[_id];
+        emit CreditLineCancelled(_id);
     }
 
     /**


### PR DESCRIPTION
## Description

A credit line uses two struct variables CreditLineConstants and CreditLineVariables which occupy storage when a credit line is created. When a credit line is closed, the status variable is set to CLOSED but the occupied storage is not freed.

## Integration Checklist

- [ ] Write tests calling public/external functions after a particular creditline has been closed and make sure that no function throws unexpected values
- [ ] Savings in gas cost can be compared using gasReport.md

## Change Log
Once a credit line has been closed, the associated creditLineConstants and creditLineVariables are deleted.