### PR TITLE
CS Audit, Lime 173, Corrected the docs

### DIFF
--- a/contracts/Pool/Extension.sol
+++ b/contracts/Pool/Extension.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.7.0;
 
 import '@openzeppelin/contracts-upgradeable/proxy/Initializable.sol';
-import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
 import '../interfaces/IPool.sol';
 import '../interfaces/IPoolFactory.sol';
 import '../interfaces/IExtension.sol';

--- a/contracts/Pool/Repayments.sol
+++ b/contracts/Pool/Repayments.sol
@@ -292,7 +292,7 @@ contract Repayments is Initializable, IRepayment, ReentrancyGuard {
         return _interestLeft;
     }
 
-    /// @notice Given there is no loan extension, find the overdue interest after missing the repayment deadline
+    /// @notice Given there is a loan extension, find the overdue interest after missing the repayment deadline
     /// @dev (10**30) is included to maintain the accuracy of the arithmetic operations
     /// @param _poolID address of the pool
     /// @return interest amount that is overdue


### PR DESCRIPTION
## Description

The function Repayments.getInterestOverdue has a wrong description since it considers a case when there is a loan extension.

## Change Log

Erroneous function description was corrected.