### PR TITLE
CS Audit, Lime 172, Corrected the docs

### DIFF
--- a/contracts/Pool/Extension.sol
+++ b/contracts/Pool/Extension.sol
@@ -35,7 +35,7 @@ contract Extension is Initializable, IExtension {
     uint256 public votingPassRatio;
 
     /**
-     * @notice checks if the msg.sender is pool's valid owner
+     * @notice checks if the msg.sender is pool factory's valid owner
      */
     modifier onlyOwner() {
         require(msg.sender == poolFactory.owner(), 'Not owner');


### PR DESCRIPTION
## Description

Extension.sol

• The modifier onlyOwner checks if the msg.sender == poolFactory.owner, while the specification says it checks if the pool's owner.

## Change Log

The modifier was correct and checking the correct thing, however the comment was not very clear which has been rectified.