### PR TITLE
CS lime-182, Collateral Ratio Check Differs From Specification

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -704,7 +704,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
             (_currentDebt.add(_amount)).mul(10**_decimals)
         );
         require(
-            _collateralRatioIfAmountIsWithdrawn > creditLineConstants[_id].idealCollateralRatio,
+            _collateralRatioIfAmountIsWithdrawn >= creditLineConstants[_id].idealCollateralRatio,
             "CreditLine::borrow - The current collateral ratio doesn't allow to withdraw the amount"
         );
         address _borrowAsset = creditLineConstants[_id].borrowAsset;


### PR DESCRIPTION
# Description
The specification states: > Borrower's collateral ratio after the borrow must be greater than or equal to idealCollateralRatio as defined by the credit line instance. However, the code requires the collateral ratio to be always greater than the idealCollateralRatio: 

require(_collateralRatioIfAmountIsWithdrawn > creditLineConstants[_id].idealCollateralRatio)

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Using the correct comparison of `idealCollateralRatio`.

# Event Signature Changes

# Function Signature Changes

# Features

# Events

