### PR TITLE
CS lime-189, Inefficient Struct Packing

### DIFF
--- a/contracts/Pool/Extension.sol
+++ b/contracts/Pool/Extension.sol
@@ -19,9 +19,9 @@ contract Extension is Initializable, IExtension {
     struct ExtensionVariables {
         bool hasExtensionPassed;
         uint64 extensionVoteEndTime;
-        mapping(address => uint64) lastVotedExtension;
+        uint128 repaymentInterval;
+        mapping(address => uint256) lastVotedExtension;
         uint256 totalExtensionSupport;
-        uint256 repaymentInterval;
     }
 
     /**
@@ -65,7 +65,7 @@ contract Extension is Initializable, IExtension {
      * @notice initializing the pool extension for the Pool
      * @param _repaymentInterval value of the repayment interval
      */
-    function initializePoolExtension(uint256 _repaymentInterval) external override {
+    function initializePoolExtension(uint128 _repaymentInterval) external override {
         IPoolFactory _poolFactory = poolFactory;
         require(extensions[msg.sender].repaymentInterval == 0, 'Extension::initializePoolExtension - already initialized');
         require(_poolFactory.poolRegistry(msg.sender), 'Repayments::onlyValidPool - Invalid Pool');
@@ -110,7 +110,7 @@ contract Extension is Initializable, IExtension {
             return;
         }
 
-        uint64 _extensionVoteEndTime = extensions[_pool].extensionVoteEndTime;
+        uint256 _extensionVoteEndTime = extensions[_pool].extensionVoteEndTime;
 
         if (_extensionVoteEndTime != 0 && _extensionVoteEndTime <= block.timestamp) {
             if (extensions[_pool].lastVotedExtension[_from] == _extensionVoteEndTime) {
@@ -136,7 +136,7 @@ contract Extension is Initializable, IExtension {
 
         uint256 _votingPassRatio = votingPassRatio;
 
-        uint64 _lastVotedExtension = extensions[_pool].lastVotedExtension[msg.sender]; //Lender last vote time need to store it as it checks that a lender only votes once
+        uint256 _lastVotedExtension = extensions[_pool].lastVotedExtension[msg.sender]; //Lender last vote time need to store it as it checks that a lender only votes once
         require(_lastVotedExtension != _extensionVoteEndTime, 'Pool::voteOnExtension - you have already voted');
 
         uint256 _extensionSupport = extensions[_pool].totalExtensionSupport;

--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -321,7 +321,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         require(_currentCollateralRatio >= poolConstants.idealCollateralRatio, 'WBA3');
 
         uint256 _noOfRepaymentIntervals = poolConstants.noOfRepaymentIntervals;
-        uint256 _repaymentInterval = poolConstants.repaymentInterval;
+        uint128 _repaymentInterval = uint128(poolConstants.repaymentInterval);
         IRepayment(_poolFactory.repaymentImpl()).initializeRepayment(
             _noOfRepaymentIntervals,
             _repaymentInterval,

--- a/contracts/interfaces/IExtension.sol
+++ b/contracts/interfaces/IExtension.sol
@@ -34,7 +34,7 @@ interface IExtension {
      */
     event LenderVoted(address indexed lender, uint256 totalExtensionSupport, uint256 lastVoteTime);
 
-    function initializePoolExtension(uint256 _repaymentInterval) external;
+    function initializePoolExtension(uint128 _repaymentInterval) external;
 
     function closePoolExtension() external;
 


### PR DESCRIPTION
# Description

The struct `ExtensionVariables` has three variables of type `uint256`. At least the time and interval variables could be packed together to save a slot as it is highly unlikely, that these variables need a full word.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Efficient struct packing in `Extension.sol`.

# Event Signature Changes

# Function Signature Changes

# Features

# Events

