### PR TITLE
CS lime-190, Inefficient Struct PriceData

### DIFF
--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -14,8 +14,8 @@ contract PriceOracle is Initializable, OwnableUpgradeable, IPriceOracle {
 
     uint32 uniswapPriceAveragingPeriod;
     struct PriceData {
+        uint64 decimals;
         address oracle;
-        uint256 decimals;
     }
     /**
      * @notice stores the price oracle and its decimals for chainlink feeds
@@ -158,8 +158,8 @@ contract PriceOracle is Initializable, OwnableUpgradeable, IPriceOracle {
      * @param priceOracle addrewss of the price feed for the token
      **/
     function setChainlinkFeedAddress(address token, address priceOracle) external onlyOwner {
-        uint256 priceOracleDecimals = AggregatorV3Interface(priceOracle).decimals();
-        chainlinkFeedAddresses[token] = PriceData(priceOracle, priceOracleDecimals);
+        uint64 priceOracleDecimals = uint64(AggregatorV3Interface(priceOracle).decimals());
+        chainlinkFeedAddresses[token] = PriceData(priceOracleDecimals, priceOracle);
         decimals[token] = getDecimals(token);
         emit ChainlinkFeedUpdated(token, priceOracle);
     }


### PR DESCRIPTION
# Description
The struct PriceData has two variables and is defined as: 

struct PriceData { address oracle; uint256 decimals; } 

decimals stores the number of decimals that the price is returned, hence its range is limited (currently the code returns prices with 30 decimals). Given that address occupies 20 bytes, the struct can be packed together in a single storage slot.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Efficient struct packing in `PriceOracle.sol`.

# Event Signature Changes

# Function Signature Changes

# Features

# Events

