### PR TITLE
CS lime-193, No Event Emitted on Emergency Withdrawal

### DIFF
--- a/contracts/interfaces/IYield.sol
+++ b/contracts/interfaces/IYield.sol
@@ -2,6 +2,15 @@
 pragma solidity 0.7.0;
 
 interface IYield {
+
+    /**
+     * @notice emitted when all tokens are withdrawn, in case of emergencies
+     * @param asset address of the token being withdrawn
+     * @param withdrawTo address of the wallet to which tokens are withdrawn
+     * @param tokensReceived amount of tokens received
+     */
+    event EmergencyWithdraw(address indexed asset, address indexed withdrawTo, uint256 tokensReceived);
+    
     /**
      * @dev emitted when tokens are locked
      * @param user the address of user, tokens locked for

--- a/contracts/interfaces/IYield.sol
+++ b/contracts/interfaces/IYield.sol
@@ -4,14 +4,6 @@ pragma solidity 0.7.0;
 interface IYield {
 
     /**
-     * @notice emitted when all tokens are withdrawn, in case of emergencies
-     * @param asset address of the token being withdrawn
-     * @param withdrawTo address of the wallet to which tokens are withdrawn
-     * @param tokensReceived amount of tokens received
-     */
-    event EmergencyWithdraw(address indexed asset, address indexed withdrawTo, uint256 tokensReceived);
-    
-    /**
      * @dev emitted when tokens are locked
      * @param user the address of user, tokens locked for
      * @param investedTo the address of contract to invest in

--- a/contracts/yield/AaveYield.sol
+++ b/contracts/yield/AaveYield.sol
@@ -46,6 +46,16 @@ contract AaveYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard
      */
     uint16 public referralCode;
 
+
+    /**
+     * @notice emitted when all tokens are withdrawn, in case of emergencies
+     * @param asset address of the token being withdrawn
+     * @param withdrawTo address of the wallet to which tokens are withdrawn
+     * @param tokensReceived amount of tokens received
+     */
+    event EmergencyWithdraw(address indexed asset, address indexed withdrawTo, uint256 tokensReceived);
+    
+
     /**
      * @notice emitted when aave protocol related addresses are updated
      * @param wethGateway address of wethGateway

--- a/contracts/yield/AaveYield.sol
+++ b/contracts/yield/AaveYield.sol
@@ -167,6 +167,7 @@ contract AaveYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard
      * @dev only owner can withdraw
      * @param _asset address of the token being withdrawn
      * @param _wallet address to which tokens are withdrawn
+     * @return received amount of tokens received
      */
     function emergencyWithdraw(address _asset, address payable _wallet) external onlyOwner returns (uint256 received) {
         require(_wallet != address(0), 'cant burn');
@@ -180,6 +181,7 @@ contract AaveYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard
             received = _withdrawERC(_asset, amount);
             IERC20(_asset).safeTransfer(_wallet, received);
         }
+        emit EmergencyWithdraw(_asset,_wallet,received);
     }
 
     /**

--- a/contracts/yield/CompoundYield.sol
+++ b/contracts/yield/CompoundYield.sol
@@ -29,6 +29,16 @@ contract CompoundYield is IYield, Initializable, OwnableUpgradeable, ReentrancyG
      */
     mapping(address => address) public override liquidityToken;
 
+
+    /**
+     * @notice emitted when all tokens are withdrawn, in case of emergencies
+     * @param asset address of the token being withdrawn
+     * @param withdrawTo address of the wallet to which tokens are withdrawn
+     * @param tokensReceived amount of tokens received
+     */
+    event EmergencyWithdraw(address indexed asset, address indexed withdrawTo, uint256 tokensReceived);
+    
+
     /**
      * @notice emitted when liquidity token address of an asset is updated
      * @param asset the address of asset

--- a/contracts/yield/CompoundYield.sol
+++ b/contracts/yield/CompoundYield.sol
@@ -88,6 +88,7 @@ contract CompoundYield is IYield, Initializable, OwnableUpgradeable, ReentrancyG
      * @dev only owner can withdraw
      * @param _asset address of the token being withdrawn
      * @param _wallet address to which tokens are withdrawn
+     * @return received amount of tokens received
      */
     function emergencyWithdraw(address _asset, address payable _wallet) external onlyOwner returns (uint256 received) {
         require(_wallet != address(0), 'cant burn');
@@ -102,6 +103,7 @@ contract CompoundYield is IYield, Initializable, OwnableUpgradeable, ReentrancyG
             received = _withdrawERC(_asset, investedTo, amount);
             IERC20(_asset).safeTransfer(_wallet, received);
         }
+        emit EmergencyWithdraw(_asset,_wallet,received);
     }
 
     /**

--- a/contracts/yield/NoYield.sol
+++ b/contracts/yield/NoYield.sol
@@ -24,6 +24,16 @@ contract NoYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard {
      **/
     address payable public savingsAccount;
 
+
+    /**
+     * @notice emitted when all tokens are withdrawn, in case of emergencies
+     * @param asset address of the token being withdrawn
+     * @param withdrawTo address of the wallet to which tokens are withdrawn
+     * @param tokensReceived amount of tokens received
+     */
+    event EmergencyWithdraw(address indexed asset, address indexed withdrawTo, uint256 tokensReceived);
+    
+
     /**
      * @notice checks if contract is invoked by savings account
      **/

--- a/contracts/yield/NoYield.sol
+++ b/contracts/yield/NoYield.sol
@@ -74,12 +74,14 @@ contract NoYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard {
      * @dev only owner can withdraw
      * @param _asset address of the token being withdrawn
      * @param _wallet address to which tokens are withdrawn
+     * @return received amount of tokens received
      */
     function emergencyWithdraw(address _asset, address payable _wallet) external onlyOwner returns (uint256 received) {
         require(_wallet != address(0), 'cant burn');
         uint256 amount = IERC20(_asset).balanceOf(address(this));
         IERC20(_asset).safeTransfer(_wallet, received);
         received = amount;
+        emit EmergencyWithdraw(_asset,_wallet,received);
     }
 
     /**

--- a/contracts/yield/YearnYield.sol
+++ b/contracts/yield/YearnYield.sol
@@ -23,6 +23,16 @@ contract YearnYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuar
      **/
     address payable public savingsAccount;
 
+
+    /**
+     * @notice emitted when all tokens are withdrawn, in case of emergencies
+     * @param asset address of the token being withdrawn
+     * @param withdrawTo address of the wallet to which tokens are withdrawn
+     * @param tokensReceived amount of tokens received
+     */
+    event EmergencyWithdraw(address indexed asset, address indexed withdrawTo, uint256 tokensReceived);
+    
+
     /**
      * @notice stores the address of liquidity token for a given base token
      */

--- a/contracts/yield/YearnYield.sol
+++ b/contracts/yield/YearnYield.sol
@@ -87,6 +87,7 @@ contract YearnYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuar
      * @dev only owner can withdraw
      * @param _asset address of the token being withdrawn
      * @param _wallet address to which tokens are withdrawn
+     * @return received amount of tokens received
      */
     function emergencyWithdraw(address _asset, address payable _wallet) external onlyOwner nonReentrant returns (uint256 received) {
         require(_wallet != address(0), 'cant burn');
@@ -101,6 +102,7 @@ contract YearnYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuar
             received = _withdrawERC(_asset, investedTo, amount);
             IERC20(_asset).safeTransfer(_wallet, received);
         }
+        emit EmergencyWithdraw(_asset,_wallet,received);
     }
 
     /**


### PR DESCRIPTION
# Description
All saving strategies implement a function emergencyWithdraw(address _asset, address payable _wallet) which allows the owner to transfer all tokens of an _asset to an arbitrary address _wallet. Due to the sensitivity of this operation, an event should be emitted when the emergency withdraw executes.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Adding EmergencyWithdraw event in `IYield.sol`, `AaveYield.sol`, `CompoundYield.sol`, `YearnYield.sol` and `NoYield.sol`.
- Adding comments for `emergencyWithdraw` function in all strategy contracts.

# Event Signature Changes

# Function Signature Changes

# Features

# Events

