### PR TITLE
CS lime-212, Redundant Check on Strategy List 

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -485,7 +485,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         for (uint256 _index = 0; _index < _strategyList.length; _index++) {
             address _strategy = _strategyList[_index];
             uint256 _liquidityShares = _savingsAccount.balanceInShares(_sender, _collateralAsset, _strategy);
-            if (_liquidityShares == 0 || _strategyList[_index] == address(0)) {
+            if (_liquidityShares == 0) {
                 continue;
             }
             uint256 _tokenInStrategy = _liquidityShares;
@@ -623,7 +623,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         uint256 _amount,
         address _strategy,
         bool _fromSavingsAccount
-    ) external payable nonReentrant ifCreditLineExists(_id) {
+    ) external payable nonReentrant {
         require(creditLineVariables[_id].status == CreditLineStatus.ACTIVE, 'CreditLine not active');
         _depositCollateral(_id, _amount, _strategy, _fromSavingsAccount);
         emit CollateralDeposited(_id, _amount, _strategy);
@@ -661,9 +661,6 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         ISavingsAccount _savingsAccount = ISavingsAccount(savingsAccount);
         uint256 _activeAmount;
         for (uint256 _index = 0; _index < _strategyList.length; _index++) {
-            if (_strategyList[_index] == address(0)) {
-                continue;
-            }
             uint256 _liquidityShares = _savingsAccount.balanceInShares(_lender, _asset, _strategyList[_index]);
             if (_liquidityShares != 0) {
                 uint256 tokenInStrategy = _liquidityShares;
@@ -751,9 +748,6 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         uint256 _activeAmount;
 
         for (uint256 _index = 0; _index < _strategyList.length; _index++) {
-            if (_strategyList[_index] == address(0)) {
-                continue;
-            }
             uint256 _liquidityShares = _savingsAccount.balanceInShares(msg.sender, _asset, _strategyList[_index]);
             if (_liquidityShares == 0) {
                 continue;
@@ -863,7 +857,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
      * @dev used to close credit line by borrower or lender
      * @param _id identifier for the credit line
      */
-    function close(uint256 _id) external ifCreditLineExists(_id) {
+    function close(uint256 _id) external {
         require(
             msg.sender == creditLineConstants[_id].borrower || msg.sender == creditLineConstants[_id].lender,
             'CreditLine: Permission denied while closing Line of credit'

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -456,9 +456,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
 
             if (_liquidityShares != 0) {
                 uint256 _tokenInStrategy = _liquidityShares;
-                if (_strategyList[i] != address(0)) {
-                    _tokenInStrategy = IYield(_strategyList[i]).getTokensForShares(_liquidityShares, _token);
-                }
+                _tokenInStrategy = IYield(_strategyList[i]).getTokensForShares(_liquidityShares, _token);
 
                 _totalTokens = _totalTokens.add(_tokenInStrategy);
             }

--- a/test/CreditLines/1.spec.ts
+++ b/test/CreditLines/1.spec.ts
@@ -574,13 +574,13 @@ describe('Credit Lines', async () => {
                         creditLine
                             .connect(borrower)
                             .depositCollateral(randomInvalidHash, BigNumber.from('123123123'), yearnYield.address, false)
-                    ).to.be.revertedWith('Credit line does not exist');
+                    ).to.be.revertedWith('CreditLine not active');
 
                     await expect(
                         creditLine
                             .connect(borrower)
                             .depositCollateral(randomInvalidHash, BigNumber.from('123123123'), yearnYield.address, true)
-                    ).to.be.revertedWith('Credit line does not exist');
+                    ).to.be.revertedWith('CreditLine not active');
                 });
 
                 it('should fail if any other user/address is trying to accept the credit line', async () => {


### PR DESCRIPTION
# Description
Several functions in SavingsAccount and CreditLine contracts iterate through the list of strategies. The functions make two sanity checks: 

• balanceInShares[_user][_token][_strategy] != 0, 

• _strategyList[i] != address(0).

The second check is unnecessary because if _strategyList[i] is equal to address(0), the first check would be false.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Removing redundant checks for strategy in `CreditLine.sol`.
- Removing redundant checks for strategy in `SavingsAccount.sol`.

# Event Signature Changes

# Function Signature Changes

# Features

# Events

