### PR TITLE
CS lime-213, Redundant Checks

### DIFF
--- a/contracts/yield/AaveYield.sol
+++ b/contracts/yield/AaveYield.sol
@@ -194,8 +194,6 @@ contract AaveYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard
         address asset,
         uint256 amount
     ) external payable override onlySavingsAccount nonReentrant returns (uint256 sharesReceived) {
-        require(amount != 0, 'Invest: amount');
-
         address investedTo;
         if (asset == address(0)) {
             require(msg.value == amount, 'Invest: ETH amount');
@@ -215,8 +213,6 @@ contract AaveYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard
      * @return received amount of tokens received
      **/
     function unlockTokens(address asset, uint256 amount) external override onlySavingsAccount nonReentrant returns (uint256 received) {
-        require(amount != 0, 'Invest: amount');
-
         if (asset == address(0)) {
             received = _withdrawETH(amount);
             (bool success, ) = savingsAccount.call{value: received}('');

--- a/contracts/yield/CompoundYield.sol
+++ b/contracts/yield/CompoundYield.sol
@@ -117,7 +117,6 @@ contract CompoundYield is IYield, Initializable, OwnableUpgradeable, ReentrancyG
         address asset,
         uint256 amount
     ) external payable override onlySavingsAccount nonReentrant returns (uint256 sharesReceived) {
-        require(amount != 0, 'Invest: amount');
         address investedTo = liquidityToken[asset];
         if (asset == address(0)) {
             require(msg.value == amount, 'Invest: ETH amount');
@@ -136,7 +135,6 @@ contract CompoundYield is IYield, Initializable, OwnableUpgradeable, ReentrancyG
      * @return received amount of tokens received
      **/
     function unlockTokens(address asset, uint256 amount) external override onlySavingsAccount nonReentrant returns (uint256 received) {
-        require(amount != 0, 'Invest: amount');
         address investedTo = liquidityToken[asset];
 
         if (asset == address(0)) {

--- a/contracts/yield/NoYield.sol
+++ b/contracts/yield/NoYield.sol
@@ -95,7 +95,6 @@ contract NoYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard {
         address asset,
         uint256 amount
     ) external payable override onlySavingsAccount nonReentrant returns (uint256 sharesReceived) {
-        require(amount != 0, 'Invest: amount');
         if (asset != address(0)) {
             IERC20(asset).safeTransferFrom(user, address(this), amount);
         } else {
@@ -132,7 +131,6 @@ contract NoYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuard {
     }
 
     function _unlockTokens(address asset, uint256 amount) internal returns (uint256 received) {
-        require(amount != 0, 'Invest: amount');
         received = amount;
         if (asset == address(0)) {
             (bool success, ) = savingsAccount.call{value: received}('');

--- a/contracts/yield/YearnYield.sol
+++ b/contracts/yield/YearnYield.sol
@@ -116,8 +116,6 @@ contract YearnYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuar
         address asset,
         uint256 amount
     ) external payable override onlySavingsAccount nonReentrant returns (uint256 sharesReceived) {
-        require(amount != 0, 'Invest: amount');
-
         address investedTo = liquidityToken[asset];
         if (asset == address(0)) {
             require(msg.value == amount, 'Invest: ETH amount');
@@ -137,7 +135,6 @@ contract YearnYield is IYield, Initializable, OwnableUpgradeable, ReentrancyGuar
      * @return received amount of tokens received
      **/
     function unlockTokens(address asset, uint256 amount) external override onlySavingsAccount nonReentrant returns (uint256 received) {
-        require(amount != 0, 'Invest: amount');
         address investedTo = liquidityToken[asset];
 
         if (asset == address(0)) {


### PR DESCRIPTION
# Description
All implementations of the function lockTokens in the strategy contracts perform a check that the amount != 0. This function is called only by deposit in the savingAccount contract which already does this check. The same applies for unlockTokens in switchStrategy. The functions withdraw and withdrawAll do not perform the check. 

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Removing redundant checks from strategy contracts.

# Event Signature Changes

# Function Signature Changes

# Features

# Events

