### PR TITLE
CS lime-214, Redundant Definition of LoanStatus

### DIFF
--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -25,15 +25,6 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
     using SafeERC20 for IERC20;
     using SafeMath for uint256;
 
-    enum LoanStatus {
-        COLLECTION, //denotes collection period
-        ACTIVE, // denotes the active loan
-        CLOSED, // Loan is repaid and closed
-        CANCELLED, // Cancelled by borrower
-        DEFAULTED, // Repayment defaulted by  borrower
-        TERMINATED // Pool terminated by admin
-    }
-
     address poolFactory;
 
     struct LendingDetails {

--- a/contracts/Pool/Repayments.sol
+++ b/contracts/Pool/Repayments.sol
@@ -25,15 +25,6 @@ contract Repayments is Initializable, IRepayment, ReentrancyGuard {
 
     IPoolFactory poolFactory;
 
-    enum LoanStatus {
-        COLLECTION, //denotes collection period
-        ACTIVE, // denotes the active loan
-        CLOSED, // Loan is repaid and closed
-        CANCELLED, // Cancelled by borrower
-        DEFAULTED, // Repaymennt defaulted by  borrower
-        TERMINATED // Pool terminated by admin
-    }
-
     uint256 gracePenaltyRate;
     uint256 gracePeriodFraction; // fraction of the repayment interval
 
@@ -383,7 +374,7 @@ contract Repayments is Initializable, IRepayment, ReentrancyGuard {
         _amount = _amount * 10**30;
         {
             uint256 _loanStatus = _pool.getLoanStatus();
-            require(_loanStatus == 1, 'Repayments:repayInterest Pool should be active.');
+            require(_loanStatus == uint256(IPool.LoanStatus.ACTIVE), 'Repayments:repayInterest Pool should be active.');
         }
 
         uint256 _initialAmount = _amount;

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -2,6 +2,15 @@
 pragma solidity 0.7.0;
 
 interface IPool {
+    
+    enum LoanStatus {
+        COLLECTION, //denotes collection period
+        ACTIVE, // denotes the active loan
+        CLOSED, // Loan is repaid and closed
+        CANCELLED, // Cancelled by borrower
+        DEFAULTED, // Repaymennt defaulted by  borrower
+        TERMINATED // Pool terminated by admin
+    }
     /**
      * @notice Emitted when pool is cancelled either on borrower request or insufficient funds collected
      */


### PR DESCRIPTION
# Description
The struct LoanStatus is defined in the Repayments contract as well as in the Pool contract. This could result in inconsistent definitions if not both are kept in sync with each change.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Defining LoanStatus only once in IPool interface to reduce duplicity.

# Event Signature Changes

# Function Signature Changes

# Features

# Events

