### PR TITLE
CS lime-223, Unused State in CreditLineStatus

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -26,7 +26,6 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
         REQUESTED,
         ACTIVE,
         CLOSED,
-        CANCELLED,
         LIQUIDATED
     }
 


### PR DESCRIPTION
# Description
The enum CreditLineStatus defines the state CANCELLED which is not used anywhere in the code.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Removing unused CreditLine status

# Event Signature Changes

# Function Signature Changes

# Features

# Events

