### PR TITLE
CS lime-169, Updating the comments in Creditline.sol 

### DIFF
--- a/contracts/CreditLine/CreditLine.sol
+++ b/contracts/CreditLine/CreditLine.sol
@@ -95,7 +95,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
 
     /**
      * @notice stores the fraction of borrowed amount charged as fee by protocol
-     * @dev it is multiplied by 10**30
+     * @dev it is multiplied by 10**30 (precision)
      **/
     uint256 public protocolFeeFraction;
 
@@ -106,7 +106,7 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
 
     /**
      * @notice stores the fraction of amount liquidated given as reward to liquidator
-     * @dev it is multiplied by 10**30
+     * @dev it is multiplied by 10**30 (precision)
      **/
     uint256 public liquidatorRewardFraction;
     /**
@@ -375,8 +375,9 @@ contract CreditLine is ReentrancyGuard, OwnableUpgradeable {
 
     /**
      * @dev Used to Calculate Interest Per second on given principal and Interest rate
-     * @param _principal principal Amount for which interest has to be calculated.
+     * @param _principal principal Amount for which interest has to be calculated
      * @param _borrowRate It is the Interest Rate at which Credit Line is approved
+     * @param _timeElapsed It is the time interval in seconds for which interest is calculated
      * @return interest per second for the given parameters
      */
     function calculateInterest(


### PR DESCRIPTION
# Description
• Parameter _timeElapsed lacks description in calculateInterest. 

• State variables protocolFeeFraction and liquidatorRewardFraction have a ambiguous description: it is multiplied by 10**30.

# Integrations Checklist

- [ ]  Have any function signatures changed? If yes, outline below.
- [ ]  Have any features changed or been added? If yes, outline below.
- [ ]  Have any events changed or been added? If yes, outline below.
- [ ]  Has all documentation been updated?

# Changelog

- Adding the correct comments in creditline.sol

# Event Signature Changes

# Function Signature Changes

# Features

# Events

