### PR TITLE
CS Audit, LIME-165, fixed poolToken decimals issue

### DIFF
--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.7.6;
+pragma solidity 0.7.0;
 
 import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.7.0;
+pragma solidity 0.7.6;
 
 import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 import '@openzeppelin/contracts/math/SafeMath.sol';
@@ -37,7 +37,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
     address poolFactory;
 
     struct LendingDetails {
-        uint256 interestWithdrawn;
+        uint256 effectiveInterestWithdrawn;
         uint256 marginCallEndTime;
         uint256 extraLiquidityShares;
     }
@@ -162,7 +162,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         poolConstants.loanStartTime = block.timestamp.add(_collectionPeriod);
         poolConstants.loanWithdrawalDeadline = block.timestamp.add(_collectionPeriod).add(_loanWithdrawalDuration);
         __ERC20_init('Pool Tokens', 'PT');
-        try ERC20Upgradable(_borrowAsset).decimals() returns(uint8 _decimals) {
+        try ERC20Upgradeable(_borrowAsset).decimals() returns(uint8 _decimals) {
             _setupDecimals(_decimals);
         } catch(bytes memory) {}
     }
@@ -339,10 +339,12 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         uint256 _protocolFee = _tokensLent.mul(_protocolFeeFraction).div(10**30);
         delete poolConstants.loanWithdrawalDeadline;
 
-        SavingsAccountUtil.transferTokens(_borrowAsset, _protocolFee, address(this), _collector);
-        SavingsAccountUtil.transferTokens(_borrowAsset, _tokensLent.sub(_protocolFee), address(this), msg.sender);
+        uint256 _feeAdjustedWithdrawalAmount = _tokensLent.sub(_protocolFee);
 
-        emit AmountBorrowed(_tokensLent);
+        SavingsAccountUtil.transferTokens(_borrowAsset, _protocolFee, address(this), _collector);
+        SavingsAccountUtil.transferTokens(_borrowAsset, _feeAdjustedWithdrawalAmount, address(this), msg.sender);
+
+        emit AmountBorrowed(_feeAdjustedWithdrawalAmount, _protocolFee);
     }
 
     /**
@@ -388,7 +390,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
     function lend(
         address _lender,
         uint256 _amount,
-        bool _strategy
+        address _strategy
     ) external payable nonReentrant {
         address _lenderVerifier = poolConstants.lenderVerifier;
         address _borrower = poolConstants.borrower;
@@ -440,26 +442,44 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         if (_from == address(0) || _to == address(0)) {
             return;
         }
+        IPoolFactory _poolFactory = IPoolFactory(poolFactory);
+        address _lenderVerifier = poolConstants.lenderVerifier;
+        if (_lenderVerifier != address(0)) {
+            require(IVerification(_poolFactory.userRegistry()).isUser(_to, _lenderVerifier), 'TT5');
+        }
         require(getMarginCallEndTime(_from) == 0, 'TT3');
         require(getMarginCallEndTime(_to) == 0, 'TT4');
 
         //Withdraw repayments for user
+
+        //We enforce pending interest withdrawals before the transfers
+        
+        //effectiveInterestWithdrawn stores the interest we assume addresses have withdrawn to simplify future interest withdrawals.
+        // For eg, if _from has 100 pool tokens, _to has 50 pool tokens, and _amount is 50, the effectiveInterestWithdrawn for 
+        // _from is done using 50 pool tokens, since future interest repayment withdrawals are done with respect to 50 tokens for _from
+        // Similarly, we use 100 for _to's effectiveInterestWithdrawn calculation since their future interest withdrawals are calculated
+        // based on 100 pool tokens. Refer calculateRepaymentWithdrawable()
         _withdrawRepayment(_from);
         _withdrawRepayment(_to);
+        uint256 _totalRepaidAmount = IRepayment(IPoolFactory(poolFactory).repaymentImpl()).getTotalRepaidAmount(address(this));
+        uint256 _totalSupply = totalSupply();
+        uint256 _fromBalance = balanceOf(_from);
+        uint256 _toBalance = balanceOf(_to);
+        lenders[_from].effectiveInterestWithdrawn = (_fromBalance.sub(_amount)).mul(_totalRepaidAmount).div(_totalSupply);
+        lenders[_to].effectiveInterestWithdrawn = (_toBalance.add(_amount)).mul(_totalRepaidAmount).div(_totalSupply);
 
-        IExtension(IPoolFactory(poolFactory).extension()).removeVotes(_from, _to, _amount);
+        IExtension(_poolFactory.extension()).removeVotes(_from, _to, _amount);
 
         //transfer extra liquidity shares
         uint256 _liquidityShare = lenders[_from].extraLiquidityShares;
         if (_liquidityShare == 0) return;
 
         uint256 toTransfer = _liquidityShare;
-        if (_amount != balanceOf(_from)) {
-            toTransfer = (_amount.mul(_liquidityShare)).div(balanceOf(_from));
+        if (_amount != _fromBalance) {
+            toTransfer = (_amount.mul(_liquidityShare)).div(_fromBalance);
         }
 
         lenders[_from].extraLiquidityShares = lenders[_from].extraLiquidityShares.sub(toTransfer);
-
         lenders[_to].extraLiquidityShares = lenders[_to].extraLiquidityShares.add(toTransfer);
     }
 
@@ -502,11 +522,11 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         uint256 _cancelPenaltyMultiple = _poolFactory.poolCancelPenaltyMultiple();
         uint256 penalty = _cancelPenaltyMultiple
             .mul(poolConstants.borrowRate)
+            .div(10**30)
             .mul(_collateralLiquidityShare)
             .div(10**30)
             .mul(_penaltyTime)
-            .div(365 days)
-            .div(10**30);
+            .div(365 days);
         _cancelPool(penalty);
     }
 
@@ -516,7 +536,6 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
      */
     function _cancelPool(uint256 _penalty) internal {
         poolVariables.loanStatus = LoanStatus.CANCELLED;
-        IExtension(IPoolFactory(poolFactory).extension()).closePoolExtension();
         _withdrawAllCollateral(poolConstants.borrower, _penalty);
         _pause();
         emit PoolCancelled();
@@ -926,7 +945,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         uint256 _totalRepaidAmount = IRepayment(IPoolFactory(poolFactory).repaymentImpl()).getTotalRepaidAmount(address(this));
 
         uint256 _amountWithdrawable = (balanceOf(_lender).mul(_totalRepaidAmount).div(totalSupply())).sub(
-            lenders[_lender].interestWithdrawn
+            lenders[_lender].effectiveInterestWithdrawn
         );
 
         return _amountWithdrawable;
@@ -949,7 +968,7 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         if (_amountToWithdraw == 0) {
             return;
         }
-        lenders[_lender].interestWithdrawn = lenders[_lender].interestWithdrawn.add(_amountToWithdraw);
+        lenders[_lender].effectiveInterestWithdrawn = lenders[_lender].effectiveInterestWithdrawn.add(_amountToWithdraw);
 
         SavingsAccountUtil.transferTokens(poolConstants.borrowAsset, _amountToWithdraw, address(this), _lender);
     }

--- a/contracts/Pool/Pool.sol
+++ b/contracts/Pool/Pool.sol
@@ -162,6 +162,9 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         poolConstants.loanStartTime = block.timestamp.add(_collectionPeriod);
         poolConstants.loanWithdrawalDeadline = block.timestamp.add(_collectionPeriod).add(_loanWithdrawalDuration);
         __ERC20_init('Pool Tokens', 'PT');
+        try ERC20Upgradable(_borrowAsset).decimals() returns(uint8 _decimals) {
+            _setupDecimals(_decimals);
+        } catch(bytes memory) {}
     }
 
     /**
@@ -379,12 +382,13 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
      * @notice used by lender to supply liquidity to a borrow pool
      * @param _lender address of the lender
      * @param _amount amount of liquidity supplied by the _lender
-     * @param _fromSavingsAccount if true, collateral is transferred from _lender's savings account, if false, it is transferred from _lender's wallet
+     * @param _strategy address of strategy from which tokens are lent if done from savings account, 
+     *                  in case of direct deposits, zeroAddress should be used
      */
     function lend(
         address _lender,
         uint256 _amount,
-        bool _fromSavingsAccount
+        bool _strategy
     ) external payable nonReentrant {
         address _lenderVerifier = poolConstants.lenderVerifier;
         address _borrower = poolConstants.borrower;
@@ -400,12 +404,16 @@ contract Pool is Initializable, ERC20PausableUpgradeable, IPool, ReentrancyGuard
         }
 
         address _borrowToken = poolConstants.borrowAsset;
+        bool _fromSavingsAccount;
+        if(_strategy != address(0)) {
+            _fromSavingsAccount = true;
+        }
         _deposit(
             _fromSavingsAccount,
             false,
             _borrowToken,
             _amount,
-            IPoolFactory(poolFactory).noStrategyAddress(),
+            _strategy,
             msg.sender,
             address(this)
         );

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -50,9 +50,10 @@ interface IPool {
 
     /**
      * @notice emitted when borrower withdraws loan
-     * @param amount tokens the borrower withdrew
+     * @param amount tokens the borrower withdrew, taking into account the deducted protocol fee
+     * @param protocolFee protocol fee deducted when borrower withdrew the amount
      */
-    event AmountBorrowed(uint256 amount);
+    event AmountBorrowed(uint256 amount, uint256 protocolFee);
 
     /**
      * @notice emitted when lender withdraws from borrow pool

--- a/test/Pool/Pool.spec.ts
+++ b/test/Pool/Pool.spec.ts
@@ -530,7 +530,7 @@ describe('Pool', async () => {
                 await DaiTokenContract.transfer(lender.address, OperationalAmounts._amountLent);
                 await DaiTokenContract.connect(lender).approve(pool.address, OperationalAmounts._amountLent);
 
-                await expect(pool.connect(lender).lend(lender.address, OperationalAmounts._amountLent, false))
+                await expect(pool.connect(lender).lend(lender.address, OperationalAmounts._amountLent, zeroAddress))
                     .to.emit(pool, 'LiquiditySupplied')
                     .withArgs(OperationalAmounts._amountLent, lender.address);
             });

--- a/test/Pool/PoolBorrowWithdraw.spec.ts
+++ b/test/Pool/PoolBorrowWithdraw.spec.ts
@@ -15,6 +15,7 @@ import {
     ChainLinkAggregators,
     repaymentParams,
     extensionParams,
+    verificationParams,
 } from '../../utils/constants';
 
 import DeployHelper from '../../utils/deploys';
@@ -145,7 +146,7 @@ describe('Pool Borrow Withdrawal stage', async () => {
         await strategyRegistry.connect(admin).addStrategy(noYield.address);
 
         verification = await deployHelper.helper.deployVerification();
-        await verification.connect(admin).initialize(admin.address);
+        await verification.connect(admin).initialize(admin.address, verificationParams.activationDelay);
         adminVerifier = await deployHelper.helper.deployAdminVerifier();
         await verification.connect(admin).addVerifier(adminVerifier.address);
         await adminVerifier.connect(admin).initialize(admin.address, verification.address);
@@ -266,7 +267,7 @@ describe('Pool Borrow Withdrawal stage', async () => {
                 amount = createPoolParams._poolSize.mul(testPoolFactoryParams._minborrowFraction).div(scaler).sub(10);
                 await borrowToken.connect(admin).transfer(lender.address, amount);
                 await borrowToken.connect(lender).approve(pool.address, amount);
-                await pool.connect(lender).lend(lender.address, amount, false);
+                await pool.connect(lender).lend(lender.address, amount, zeroAddress);
 
                 const { loanStartTime } = await pool.poolConstants();
                 await blockTravel(network, parseInt(loanStartTime.add(1).toString()));
@@ -389,7 +390,7 @@ describe('Pool Borrow Withdrawal stage', async () => {
                 amount = createPoolParams._poolSize.mul(testPoolFactoryParams._minborrowFraction).div(scaler).add(10);
                 await borrowToken.connect(admin).transfer(lender.address, amount);
                 await borrowToken.connect(lender).approve(pool.address, amount);
-                await pool.connect(lender).lend(lender.address, amount, false);
+                await pool.connect(lender).lend(lender.address, amount, zeroAddress);
 
                 const { loanStartTime } = await pool.poolConstants();
                 await blockTravel(network, parseInt(loanStartTime.add(1).toString()));
@@ -1177,7 +1178,7 @@ describe('Pool Borrow Withdrawal stage', async () => {
                 const amount = createPoolParams._poolSize.mul(testPoolFactoryParams._minborrowFraction).div(scaler);
                 await borrowToken.connect(admin).transfer(lender.address, amount);
                 await borrowToken.connect(lender).approve(pool.address, amount);
-                await pool.connect(lender).lend(lender.address, amount, false);
+                await pool.connect(lender).lend(lender.address, amount, zeroAddress);
 
                 const { loanStartTime } = await pool.poolConstants();
                 await blockTravel(network, parseInt(loanStartTime.add(1).toString()));
@@ -1294,7 +1295,7 @@ describe('Pool Borrow Withdrawal stage', async () => {
                 const amount = createPoolParams._borrowAmountRequested;
                 await borrowToken.connect(admin).transfer(lender.address, amount);
                 await borrowToken.connect(lender).approve(pool.address, amount);
-                await pool.connect(lender).lend(lender.address, amount, false);
+                await pool.connect(lender).lend(lender.address, amount, zeroAddress);
             });
 
             async function subject() {
@@ -1331,7 +1332,7 @@ describe('Pool Borrow Withdrawal stage', async () => {
 
                 await borrowToken.connect(admin).transfer(lender.address, amount);
                 await borrowToken.connect(lender).approve(pool.address, amount);
-                await pool.connect(lender).lend(lender.address, amount, false);
+                await pool.connect(lender).lend(lender.address, amount, zeroAddress);
                 await subject();
 
                 await pool.connect(borrower).withdrawBorrowedAmount();

--- a/test/Pool/PoolCollection.spec.ts
+++ b/test/Pool/PoolCollection.spec.ts
@@ -16,6 +16,7 @@ import {
     OperationalAmounts,
     repaymentParams,
     extensionParams,
+    verificationParams,
 } from '../../utils/constants';
 import DeployHelper from '../../utils/deploys';
 
@@ -142,7 +143,7 @@ describe('Pool Collection stage', async () => {
         await strategyRegistry.connect(admin).addStrategy(noYield.address);
 
         verification = await deployHelper.helper.deployVerification();
-        await verification.connect(admin).initialize(admin.address);
+        await verification.connect(admin).initialize(admin.address, verificationParams.activationDelay);
         adminVerifier = await deployHelper.helper.deployAdminVerifier();
         await verification.connect(admin).addVerifier(adminVerifier.address);
         await adminVerifier.connect(admin).initialize(admin.address, verification.address);
@@ -266,7 +267,7 @@ describe('Pool Collection stage', async () => {
             await borrowToken.connect(admin).transfer(lender.address, amount);
             await borrowToken.connect(lender).approve(pool.address, amount);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
 
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
 
@@ -298,7 +299,7 @@ describe('Pool Collection stage', async () => {
             const poolTokenTotalSupplyBefore = await pool.totalSupply();
             await savingsAccount.connect(lender).approve(amount, borrowToken.address, pool.address);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, true));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, noYield.address));
 
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
 
@@ -330,7 +331,7 @@ describe('Pool Collection stage', async () => {
             const poolTokenTotalSupplyBefore = await pool.totalSupply();
             await savingsAccount.connect(lender1).approve(amount, borrowToken.address, pool.address);
 
-            const lendExpect = expect(pool.connect(lender1).lend(lender.address, amount, true));
+            const lendExpect = expect(pool.connect(lender1).lend(lender.address, amount, noYield.address));
 
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
 

--- a/test/Pool/Pool_2.spec.ts
+++ b/test/Pool/Pool_2.spec.ts
@@ -15,6 +15,7 @@ import {
     ChainLinkAggregators,
     OperationalAmounts,
     extensionParams,
+    verificationParams,
 } from '../../utils/constants';
 import DeployHelper from '../../utils/deploys';
 
@@ -133,7 +134,7 @@ describe('Pool', async () => {
         await strategyRegistry.connect(admin).addStrategy(noYield.address);
 
         verification = await deployHelper.helper.deployVerification();
-        await verification.connect(admin).initialize(admin.address);
+        await verification.connect(admin).initialize(admin.address, verificationParams.activationDelay);
         adminVerifier = await deployHelper.helper.deployAdminVerifier();
         await verification.connect(admin).addVerifier(adminVerifier.address);
         await adminVerifier.connect(admin).initialize(admin.address, verification.address);
@@ -270,7 +271,7 @@ describe('Pool', async () => {
                 await DaiTokenContract.transfer(lender.address, OperationalAmounts._amountLent);
                 await DaiTokenContract.connect(lender).approve(pool.address, OperationalAmounts._amountLent);
 
-                await expect(pool.connect(lender).lend(lender.address, OperationalAmounts._amountLent, false))
+                await expect(pool.connect(lender).lend(lender.address, OperationalAmounts._amountLent, zeroAddress))
                     .to.emit(pool, 'LiquiditySupplied')
                     .withArgs(OperationalAmounts._amountLent, lender.address);
             });

--- a/test/Pool/poolActive.spec.ts
+++ b/test/Pool/poolActive.spec.ts
@@ -15,6 +15,7 @@ import {
     ChainLinkAggregators,
     repaymentParams,
     extensionParams,
+    verificationParams,
 } from '../../utils/constants';
 import DeployHelper from '../../utils/deploys';
 
@@ -143,7 +144,7 @@ describe('Pool Active stage', async () => {
         await strategyRegistry.connect(admin).addStrategy(noYield.address);
 
         verification = await deployHelper.helper.deployVerification();
-        await verification.connect(admin).initialize(admin.address);
+        await verification.connect(admin).initialize(admin.address, verificationParams.activationDelay);
         adminVerifier = await deployHelper.helper.deployAdminVerifier();
         await verification.connect(admin).addVerifier(adminVerifier.address);
         await adminVerifier.connect(admin).initialize(admin.address, verification.address);
@@ -267,11 +268,11 @@ describe('Pool Active stage', async () => {
                 // console.log({amount: amount.toString(), amount1: amount1.toString()});
                 await borrowToken.connect(admin).transfer(lender.address, amount);
                 await borrowToken.connect(lender).approve(pool.address, amount);
-                await pool.connect(lender).lend(lender.address, amount, false);
+                await pool.connect(lender).lend(lender.address, amount, zeroAddress);
 
                 await borrowToken.connect(admin).transfer(lender1.address, amount1);
                 await borrowToken.connect(lender1).approve(pool.address, amount1);
-                await pool.connect(lender1).lend(lender1.address, amount1, false);
+                await pool.connect(lender1).lend(lender1.address, amount1, zeroAddress);
 
                 const { loanStartTime } = await pool.poolConstants();
                 await blockTravel(network, parseInt(loanStartTime.add(1).toString()));

--- a/test/Pool/repayments/Pool_repayments.spec.ts
+++ b/test/Pool/repayments/Pool_repayments.spec.ts
@@ -8,6 +8,7 @@ import {
     PoolFactoryInitParams,
     PriceOracleSource,
     RepaymentsInitParams,
+    VerificationParams,
     YearnPair,
 } from '../../../utils/types';
 import hre from 'hardhat';
@@ -22,6 +23,7 @@ import {
     createPoolParams,
     zeroAddress,
     ChainLinkAggregators,
+    verificationParams,
 } from '../../../utils/constants';
 import { testVars as testCases } from './Pool_repayments_testEnv';
 
@@ -38,9 +40,10 @@ import { blockTravel } from '../../../utils/time';
 import { getPoolInitSigHash } from '../../../utils/createEnv/poolLogic';
 import { extendEnvironment } from 'hardhat/config';
 
-describe('Pool Repayment cases', function () {
-    testCases.forEach((testCase) => {
-        marginCallTests(
+describe('Pool Repayment cases', async function () {
+    for (let index = 0; index < testCases.length; index++) {
+        const testCase = testCases[index];
+        await repaymentTests(
             testCase.Amount,
             testCase.Whale1,
             testCase.Whale2,
@@ -51,10 +54,10 @@ describe('Pool Repayment cases', function () {
             testCase.chainlinkBorrow,
             testCase.chainlinkCollateral
         );
-    });
+    }
 });
 
-export async function marginCallTests(
+export async function repaymentTests(
     amount: Number,
     whaleAccount1: Address,
     whaleAccount2: Address,
@@ -65,257 +68,264 @@ export async function marginCallTests(
     chainlinkBorrow: Address,
     chainlinkCollateral: Address
 ): Promise<any> {
-    let snapshotId: any;
-
-    before(async () => {
-        snapshotId = await network.provider.request({
-            method: 'evm_snapshot',
-            params: [],
-        });
-    });
-
-    after(async () => {
-        await network.provider.request({
-            method: 'evm_revert',
-            params: [snapshotId],
-        });
-    });
-
-    describe('Pool Repayment', async () => {
-        let env: Environment;
-        let pool: Pool;
-        let poolAddress: Address;
-
-        let deployHelper: DeployHelper;
-        let borrowAsset: ERC20;
-        let collateralAsset: ERC20;
-        let iyield: IYield;
-        let Compound: CompoundYield;
-
-        const poolParams = {
-            poolSize: BigNumber.from(100),
-            borrowRate: BigNumber.from(1).mul(BigNumber.from(10).pow(28)),
-            collateralAmount: BigNumber.from(amount),
-            collateralRatio: BigNumber.from(250).mul(BigNumber.from(10).pow(28)),
-            collectionPeriod: 10000,
-            loanWithdrawalDuration: 200,
-            noOfRepaymentIntervals: 100,
-            repaymentInterval: 1000,
-        };
-        const SCALER = BigNumber.from(10).pow(30);
-
-        before(async () => {
-            env = await createEnvironment(
-                hre,
-                [whaleAccount1, whaleAccount2],
-                [
-                    { asset: borrowToken, liquidityToken: liquidityBorrowToken },
-                    { asset: collateralToken, liquidityToken: liquidityCollateralToken },
-                ] as CompoundPair[],
-                [] as YearnPair[],
-                [
-                    { tokenAddress: borrowToken, feedAggregator: chainlinkBorrow },
-                    { tokenAddress: collateralToken, feedAggregator: chainlinkCollateral },
-                ] as PriceOracleSource[],
-                {
-                    votingPassRatio: extensionParams.votingPassRatio,
-                } as ExtensionInitParams,
-                {
-                    gracePenalityRate: repaymentParams.gracePenalityRate,
-                    gracePeriodFraction: repaymentParams.gracePeriodFraction,
-                } as RepaymentsInitParams,
-                {
-                    admin: '',
-                    _collectionPeriod: testPoolFactoryParams._collectionPeriod,
-                    _loanWithdrawalDuration: testPoolFactoryParams._loanWithdrawalDuration,
-                    _marginCallDuration: testPoolFactoryParams._marginCallDuration,
-                    _gracePeriodPenaltyFraction: testPoolFactoryParams._gracePeriodPenaltyFraction,
-                    _poolInitFuncSelector: getPoolInitSigHash(),
-                    _liquidatorRewardFraction: testPoolFactoryParams._liquidatorRewardFraction,
-                    _poolCancelPenalityFraction: testPoolFactoryParams._poolCancelPenalityFraction,
-                    _protocolFeeFraction: testPoolFactoryParams._protocolFeeFraction,
-                    protocolFeeCollector: '',
-                    _minBorrowFraction: testPoolFactoryParams._minborrowFraction,
-                    noStrategy: '',
-                } as PoolFactoryInitParams,
-                CreditLineDefaultStrategy.Compound,
-                {
-                    _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
-                    _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
-            );
-
-            let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
-            let { admin, borrower, lender } = env.entities;
-            deployHelper = new DeployHelper(admin);
-            borrowAsset = await deployHelper.mock.getMockERC20Detailed(borrowToken);
-            collateralAsset = await deployHelper.mock.getMockERC20Detailed(collateralToken);
-            iyield = await deployHelper.mock.getYield(env.yields.compoundYield.address);
-
-            let BTDecimals = await borrowAsset.decimals();
-            let CTDecimals = await collateralAsset.decimals();
-
-            poolParams.poolSize = BigNumber.from(poolParams.poolSize).mul(BigNumber.from(10).pow(BTDecimals));
-            poolParams.collateralAmount = BigNumber.from(poolParams.collateralAmount).mul(BigNumber.from(10).pow(CTDecimals));
-
-            poolAddress = await calculateNewPoolAddress(env, borrowAsset, collateralAsset, iyield, salt, false, {
-                _poolSize: poolParams.poolSize,
-                _borrowRate: poolParams.borrowRate,
-                _collateralAmount: poolParams.collateralAmount,
-                _collateralRatio: poolParams.collateralRatio,
-                _collectionPeriod: poolParams.collectionPeriod,
-                _loanWithdrawalDuration: poolParams.loanWithdrawalDuration,
-                _noOfRepaymentIntervals: poolParams.noOfRepaymentIntervals,
-                _repaymentInterval: poolParams.repaymentInterval,
-            });
-
-            await collateralAsset.connect(env.impersonatedAccounts[0]).transfer(borrower.address, poolParams.collateralAmount);
-            await collateralAsset.connect(borrower).approve(poolAddress, poolParams.collateralAmount);
-
-            // Note: Transferring 3 times the poolSize to lender from whale
-            await borrowAsset.connect(env.impersonatedAccounts[0]).transfer(lender.address, poolParams.poolSize.mul(3));
-            await borrowAsset.connect(env.impersonatedAccounts[0]).transfer(borrower.address, poolParams.poolSize.mul(3));
-            await borrowAsset
-                .connect(env.impersonatedAccounts[0])
-                .transfer(env.entities.extraLenders[1].address, poolParams.poolSize.mul(3));
-
-            pool = await createNewPool(env, borrowAsset, collateralAsset, iyield, salt, false, {
-                _poolSize: poolParams.poolSize,
-                _borrowRate: poolParams.borrowRate,
-                _collateralAmount: poolParams.collateralAmount,
-                _collateralRatio: poolParams.collateralRatio,
-                _collectionPeriod: poolParams.collectionPeriod,
-                _loanWithdrawalDuration: poolParams.loanWithdrawalDuration,
-                _noOfRepaymentIntervals: poolParams.noOfRepaymentIntervals,
-                _repaymentInterval: poolParams.repaymentInterval,
-            });
-
-            assert.equal(poolAddress, pool.address, 'Generated and Actual pool address should match');
-
-            // fix default signers
-            pool = pool.connect(env.entities.borrower);
-            env.repayments = env.repayments.connect(env.entities.lender);
-            env.poolFactory = env.poolFactory.connect(env.entities.borrower);
-            env.savingsAccount = env.savingsAccount.connect(env.entities.borrower);
-        });
-
-        describe('Repay interest', () => {
-            let lentAmount: BigNumber, lentAmount1: BigNumber;
-            let totalPoolInterest: BigNumber;
+    // amount = BigNumber.from(amount).div(2).toNumber(); // reduce number by 2 for tests to pass
+    return new Promise((resolve, reject) => {
+        describe('Pool Repayment', async () => {
+            let env: Environment;
+            let pool: Pool;
+            let poolAddress: Address;
+    
+            let deployHelper: DeployHelper;
+            let borrowAsset: ERC20;
+            let collateralAsset: ERC20;
+            let iyield: IYield;
+            let Compound: CompoundYield;
+    
+            const poolParams = {
+                poolSize: BigNumber.from(100),
+                borrowRate: BigNumber.from(1).mul(BigNumber.from(10).pow(28)),
+                collateralAmount: BigNumber.from(amount),
+                collateralRatio: BigNumber.from(250).mul(BigNumber.from(10).pow(28)),
+                collectionPeriod: 10000,
+                loanWithdrawalDuration: 200,
+                noOfRepaymentIntervals: 100,
+                repaymentInterval: 1000,
+            };
+            const SCALER = BigNumber.from(10).pow(30);
+    
+            let snapshotId: any;
+    
             before(async () => {
-                const minBorrowFraction = await env.poolFactory.minBorrowFraction();
-                const minPoolSize = poolParams.poolSize.mul(minBorrowFraction).div(SCALER);
-                lentAmount = minPoolSize.mul(4).div(3);
-                await borrowAsset.connect(env.entities.lender).approve(pool.address, lentAmount);
-                await pool.connect(env.entities.lender).lend(env.entities.lender.address, lentAmount, false);
-
-                const { loanStartTime } = await pool.poolConstants();
-                await blockTravel(network, parseInt(loanStartTime.add(1).toString()));
-                await pool.connect(env.entities.borrower).withdrawBorrowedAmount();
-                totalPoolInterest = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
+                snapshotId = await network.provider.request({
+                    method: 'evm_snapshot',
+                    params: [],
+                });
             });
-
-            it('repay interest for first period', async () => {
-                const instalmentNo = (await env.repayments.getCurrentInstalmentInterval(pool.address)).div(SCALER);
-                assert(instalmentNo.toString() == '1', 'Wrong instalment');
-                const interestForFirstPeriod = (await env.repayments.getInterestDueTillInstalmentDeadline(pool.address)).div(SCALER);
-                await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestForFirstPeriod);
-                await env.repayments.connect(env.entities.extraLenders[1]).repay(pool.address, interestForFirstPeriod);
-
-                const { loanDurationCovered } = await env.repayments.repayVariables(pool.address);
-                const { repaymentInterval } = await env.repayments.repayConstants(pool.address);
-
-                expectApproxEqual(
-                    loanDurationCovered.div(SCALER),
-                    repaymentInterval.div(SCALER),
-                    1,
-                    `loanDurationCovered doesn't represent entire first period. Expected: ${repaymentInterval.div(
-                        SCALER
-                    )} Actual: ${loanDurationCovered.div(SCALER)}`
-                );
+    
+            after(async () => {
+                await network.provider.request({
+                    method: 'evm_revert',
+                    params: [snapshotId],
+                });
+                resolve(1);
             });
-
-            it("can't repay all interest for entire loan without repaying principal", async () => {
-                const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
-                // Note: interestLeft.add(1) is necessary as when div by SCALER we are cutting down the decimal parts and to ensure compelte repaymet, we should send little higher
-                await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft.add(1));
-                await expect(
-                    env.repayments.connect(env.entities.extraLenders[1]).repay(pool.address, interestLeft.add(1))
-                ).to.be.revertedWith('Repayments::repay complete interest must be repaid along with principal');
+    
+            before(async () => {
+                env = await createEnvironment(
+                    hre,
+                    [whaleAccount1, whaleAccount2],
+                    [
+                        { asset: borrowToken, liquidityToken: liquidityBorrowToken },
+                        { asset: collateralToken, liquidityToken: liquidityCollateralToken },
+                    ] as CompoundPair[],
+                    [] as YearnPair[],
+                    [
+                        { tokenAddress: borrowToken, feedAggregator: chainlinkBorrow },
+                        { tokenAddress: collateralToken, feedAggregator: chainlinkCollateral },
+                    ] as PriceOracleSource[],
+                    {
+                        votingPassRatio: extensionParams.votingPassRatio,
+                    } as ExtensionInitParams,
+                    {
+                        gracePenalityRate: repaymentParams.gracePenalityRate,
+                        gracePeriodFraction: repaymentParams.gracePeriodFraction,
+                    } as RepaymentsInitParams,
+                    {
+                        admin: '',
+                        _collectionPeriod: testPoolFactoryParams._collectionPeriod,
+                        _loanWithdrawalDuration: testPoolFactoryParams._loanWithdrawalDuration,
+                        _marginCallDuration: testPoolFactoryParams._marginCallDuration,
+                        _gracePeriodPenaltyFraction: testPoolFactoryParams._gracePeriodPenaltyFraction,
+                        _poolInitFuncSelector: getPoolInitSigHash(),
+                        _liquidatorRewardFraction: testPoolFactoryParams._liquidatorRewardFraction,
+                        _poolCancelPenalityFraction: testPoolFactoryParams._poolCancelPenalityFraction,
+                        _protocolFeeFraction: testPoolFactoryParams._protocolFeeFraction,
+                        protocolFeeCollector: '',
+                        _minBorrowFraction: testPoolFactoryParams._minborrowFraction,
+                        noStrategy: '',
+                    } as PoolFactoryInitParams,
+                    CreditLineDefaultStrategy.Compound,
+                    {
+                        _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
+                        _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
+                    } as CreditLineInitParams,
+                    {
+                        activationDelay: verificationParams.activationDelay
+                    } as VerificationParams,
+                );
+    
+                let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
+                let { admin, borrower, lender } = env.entities;
+                deployHelper = new DeployHelper(admin);
+                borrowAsset = await deployHelper.mock.getMockERC20Detailed(borrowToken);
+                collateralAsset = await deployHelper.mock.getMockERC20Detailed(collateralToken);
+                iyield = await deployHelper.mock.getYield(env.yields.compoundYield.address);
+    
+                let BTDecimals = await borrowAsset.decimals();
+                let CTDecimals = await collateralAsset.decimals();
+    
+                poolParams.poolSize = BigNumber.from(poolParams.poolSize).mul(BigNumber.from(10).pow(BTDecimals));
+                poolParams.collateralAmount = BigNumber.from(poolParams.collateralAmount).mul(BigNumber.from(10).pow(CTDecimals));
+    
+                poolAddress = await calculateNewPoolAddress(env, borrowAsset, collateralAsset, iyield, salt, false, {
+                    _poolSize: poolParams.poolSize,
+                    _borrowRate: poolParams.borrowRate,
+                    _collateralAmount: poolParams.collateralAmount,
+                    _collateralRatio: poolParams.collateralRatio,
+                    _collectionPeriod: poolParams.collectionPeriod,
+                    _loanWithdrawalDuration: poolParams.loanWithdrawalDuration,
+                    _noOfRepaymentIntervals: poolParams.noOfRepaymentIntervals,
+                    _repaymentInterval: poolParams.repaymentInterval,
+                });
+    
+                await collateralAsset.connect(env.impersonatedAccounts[0]).transfer(borrower.address, poolParams.collateralAmount);
+                await collateralAsset.connect(borrower).approve(poolAddress, poolParams.collateralAmount);
+    
+                // Note: Transferring 3 times the poolSize to lender from whale
+                await borrowAsset.connect(env.impersonatedAccounts[0]).transfer(lender.address, poolParams.poolSize.mul(3));
+                await borrowAsset.connect(env.impersonatedAccounts[0]).transfer(borrower.address, poolParams.poolSize.mul(3));
+                await borrowAsset
+                    .connect(env.impersonatedAccounts[0])
+                    .transfer(env.entities.extraLenders[1].address, poolParams.poolSize.mul(3));
+    
+                pool = await createNewPool(env, borrowAsset, collateralAsset, iyield, salt, false, {
+                    _poolSize: poolParams.poolSize,
+                    _borrowRate: poolParams.borrowRate,
+                    _collateralAmount: poolParams.collateralAmount,
+                    _collateralRatio: poolParams.collateralRatio,
+                    _collectionPeriod: poolParams.collectionPeriod,
+                    _loanWithdrawalDuration: poolParams.loanWithdrawalDuration,
+                    _noOfRepaymentIntervals: poolParams.noOfRepaymentIntervals,
+                    _repaymentInterval: poolParams.repaymentInterval,
+                });
+    
+                assert.equal(poolAddress, pool.address, 'Generated and Actual pool address should match');
+    
+                // fix default signers
+                pool = pool.connect(env.entities.borrower);
+                env.repayments = env.repayments.connect(env.entities.lender);
+                env.poolFactory = env.poolFactory.connect(env.entities.borrower);
+                env.savingsAccount = env.savingsAccount.connect(env.entities.borrower);
             });
-
-            it('should be able to repay slightly less than total interest', async () => {
-                const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
-                await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft);
-                await env.repayments.connect(env.entities.extraLenders[1]).repay(pool.address, interestLeft.sub(1));
+    
+            describe('Repay interest', () => {
+                let lentAmount: BigNumber, lentAmount1: BigNumber;
+                let totalPoolInterest: BigNumber;
+                before(async () => {
+                    const minBorrowFraction = await env.poolFactory.minBorrowFraction();
+                    const minPoolSize = poolParams.poolSize.mul(minBorrowFraction).div(SCALER);
+                    lentAmount = minPoolSize.mul(4).div(3);
+                    await borrowAsset.connect(env.entities.lender).approve(pool.address, lentAmount);
+                    await pool.connect(env.entities.lender).lend(env.entities.lender.address, lentAmount, zeroAddress);
+    
+                    const { loanStartTime } = await pool.poolConstants();
+                    await blockTravel(network, parseInt(loanStartTime.add(1).toString()));
+                    await pool.connect(env.entities.borrower).withdrawBorrowedAmount();
+                    totalPoolInterest = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
+                });
+    
+                it('repay interest for first period', async () => {
+                    const instalmentNo = (await env.repayments.getCurrentInstalmentInterval(pool.address)).div(SCALER);
+                    assert(instalmentNo.toString() == '1', 'Wrong instalment');
+                    const interestForFirstPeriod = (await env.repayments.getInterestDueTillInstalmentDeadline(pool.address)).div(SCALER);
+                    await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestForFirstPeriod);
+                    await env.repayments.connect(env.entities.extraLenders[1]).repay(pool.address, interestForFirstPeriod);
+    
+                    const { loanDurationCovered } = await env.repayments.repayVariables(pool.address);
+                    const { repaymentInterval } = await env.repayments.repayConstants(pool.address);
+    
+                    expectApproxEqual(
+                        loanDurationCovered.div(SCALER),
+                        repaymentInterval.div(SCALER),
+                        1,
+                        `loanDurationCovered doesn't represent entire first period. Expected: ${repaymentInterval.div(
+                            SCALER
+                        )} Actual: ${loanDurationCovered.div(SCALER)}`
+                    );
+                });
+    
+                it("can't repay all interest for entire loan without repaying principal", async () => {
+                    const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
+                    // Note: interestLeft.add(1) is necessary as when div by SCALER we are cutting down the decimal parts and to ensure compelte repaymet, we should send little higher
+                    await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft.add(1));
+                    await expect(
+                        env.repayments.connect(env.entities.extraLenders[1]).repay(pool.address, interestLeft.add(1))
+                    ).to.be.revertedWith('Repayments::repay complete interest must be repaid along with principal');
+                });
+    
+                it('should be able to repay slightly less than total interest', async () => {
+                    const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
+                    await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft);
+                    await env.repayments.connect(env.entities.extraLenders[1]).repay(pool.address, interestLeft.sub(1));
+                });
+    
+                it("can't repay some portion of principal", async () => {
+                    const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
+                    const principal = await pool.totalSupply();
+                    await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft.add(principal).sub(1));
+                    await expect(env.repayments.connect(env.entities.extraLenders[1]).repayPrincipal(pool.address)).to.be.revertedWith('');
+                });
+    
+                it('close loan', async () => {
+                    const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
+                    const principal = await pool.totalSupply();
+                    await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft.add(principal));
+    
+                    const collateralBeforeRepay = await env.savingsAccount.balanceInShares(
+                        env.entities.borrower.address,
+                        collateralAsset.address,
+                        iyield.address
+                    );
+                    const { baseLiquidityShares, extraLiquidityShares } = await pool.poolVariables();
+                    await env.repayments.connect(env.entities.extraLenders[1]).repayPrincipal(pool.address);
+                    const collateralAfterRepay = await env.savingsAccount.balanceInShares(
+                        env.entities.borrower.address,
+                        collateralAsset.address,
+                        iyield.address
+                    );
+                    const collateralIncrease = await iyield.callStatic.getTokensForShares(
+                        collateralAfterRepay.sub(collateralBeforeRepay),
+                        collateralAsset.address
+                    );
+    
+                    assert(
+                        collateralAfterRepay.sub(collateralBeforeRepay).eq(baseLiquidityShares.add(extraLiquidityShares)),
+                        `Collateral shares not correctly returned to borrower Expected: ${baseLiquidityShares.add(
+                            extraLiquidityShares
+                        )} Actual: ${collateralAfterRepay.sub(collateralBeforeRepay)}`
+                    );
+                    assert(
+                        collateralIncrease.gte(poolParams.collateralAmount),
+                        `Collateral locked is returned back Expected: ${poolParams.collateralAmount} Actual: ${collateralIncrease}`
+                    );
+    
+                    const loanStatus = await pool.getLoanStatus();
+                    assert(loanStatus.eq(2), "Loan hasn't closed");
+                    const borrowAssetAllowanceRemaining = await borrowAsset.allowance(
+                        env.entities.extraLenders[1].address,
+                        env.repayments.address
+                    );
+                    assert(
+                        borrowAssetAllowanceRemaining.eq(0),
+                        `Incorrect interest + principal transferred Expected: 0, Actual: ${borrowAssetAllowanceRemaining}`
+                    );
+                });
+    
+                it('lenders withdraw repayments and lent amount', async () => {
+                    const balanceDetails = await pool.getBalanceDetails(env.entities.lender.address);
+                    const balanceBefore = await borrowAsset.balanceOf(env.entities.lender.address);
+                    await pool.connect(env.entities.lender).withdrawLiquidity();
+                    const balanceAfter = await borrowAsset.balanceOf(env.entities.lender.address);
+    
+                    assert(
+                        balanceAfter.sub(balanceBefore).eq(totalPoolInterest.mul(balanceDetails[0]).div(balanceDetails[1]).add(lentAmount)),
+                        `Amount lent + interest not correctly received by lender Expected: ${totalPoolInterest
+                            .mul(balanceDetails[0])
+                            .div(balanceDetails[1])
+                            .add(lentAmount)} Actual: ${balanceAfter.sub(balanceBefore)}`
+                    );
+                });
             });
-
-            it("can't repay some portion of principal", async () => {
-                const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
-                const principal = await pool.totalSupply();
-                await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft.add(principal).sub(1));
-                await expect(env.repayments.connect(env.entities.extraLenders[1]).repayPrincipal(pool.address)).to.be.revertedWith('');
-            });
-
-            it('close loan', async () => {
-                const interestLeft = (await env.repayments.getInterestLeft(pool.address)).div(SCALER);
-                const principal = await pool.totalSupply();
-                await borrowAsset.connect(env.entities.extraLenders[1]).approve(env.repayments.address, interestLeft.add(principal));
-
-                const collateralBeforeRepay = await env.savingsAccount.balanceInShares(
-                    env.entities.borrower.address,
-                    collateralAsset.address,
-                    iyield.address
-                );
-                const { baseLiquidityShares, extraLiquidityShares } = await pool.poolVariables();
-                await env.repayments.connect(env.entities.extraLenders[1]).repayPrincipal(pool.address);
-                const collateralAfterRepay = await env.savingsAccount.balanceInShares(
-                    env.entities.borrower.address,
-                    collateralAsset.address,
-                    iyield.address
-                );
-                const collateralIncrease = await iyield.callStatic.getTokensForShares(
-                    collateralAfterRepay.sub(collateralBeforeRepay),
-                    collateralAsset.address
-                );
-
-                assert(
-                    collateralAfterRepay.sub(collateralBeforeRepay).eq(baseLiquidityShares.add(extraLiquidityShares)),
-                    `Collateral shares not correctly returned to borrower Expected: ${baseLiquidityShares.add(
-                        extraLiquidityShares
-                    )} Actual: ${collateralAfterRepay.sub(collateralBeforeRepay)}`
-                );
-                assert(
-                    collateralIncrease.gte(poolParams.collateralAmount),
-                    `Collateral locked is returned back Expected: ${poolParams.collateralAmount} Actual: ${collateralIncrease}`
-                );
-
-                const loanStatus = await pool.getLoanStatus();
-                assert(loanStatus.eq(2), "Loan hasn't closed");
-                const borrowAssetAllowanceRemaining = await borrowAsset.allowance(
-                    env.entities.extraLenders[1].address,
-                    env.repayments.address
-                );
-                assert(
-                    borrowAssetAllowanceRemaining.eq(0),
-                    `Incorrect interest + principal transferred Expected: 0, Actual: ${borrowAssetAllowanceRemaining}`
-                );
-            });
-
-            it('lenders withdraw repayments and lent amount', async () => {
-                const balanceDetails = await pool.getBalanceDetails(env.entities.lender.address);
-                const balanceBefore = await borrowAsset.balanceOf(env.entities.lender.address);
-                await pool.connect(env.entities.lender).withdrawLiquidity();
-                const balanceAfter = await borrowAsset.balanceOf(env.entities.lender.address);
-
-                assert(
-                    balanceAfter.sub(balanceBefore).eq(totalPoolInterest.mul(balanceDetails[0]).div(balanceDetails[1]).add(lentAmount)),
-                    `Amount lent + interest not correctly received by lender Expected: ${totalPoolInterest
-                        .mul(balanceDetails[0])
-                        .div(balanceDetails[1])
-                        .add(lentAmount)} Actual: ${balanceAfter.sub(balanceBefore)}`
-                );
-            });
-        });
-    });
+        })
+    })
 }

--- a/test/PoolSimulations/poolWithCompoundStrategy.spec.ts
+++ b/test/PoolSimulations/poolWithCompoundStrategy.spec.ts
@@ -20,6 +20,7 @@ import {
     OperationalAmounts,
     extensionParams,
     repaymentParams,
+    verificationParams,
 } from '../../utils/constants';
 import DeployHelper from '../../utils/deploys';
 
@@ -219,7 +220,7 @@ describe('Pool With Compound Strategy', async () => {
         adminVerifierLogic = await deployHelper.helper.deployAdminVerifier();
         let adminVerificationProxy = await deployHelper.helper.deploySublimeProxy(adminVerifierLogic.address, proxyAdmin.address);
         adminVerifier = await deployHelper.helper.getAdminVerifier(adminVerificationProxy.address);
-        await verification.connect(admin).initialize(admin.address);
+        await verification.connect(admin).initialize(admin.address, verificationParams.activationDelay);
         await adminVerifier.connect(admin).initialize(admin.address, verification.address);
         await verification.connect(admin).addVerifier(adminVerifier.address);
         await adminVerifier.connect(admin).registerUser(borrower.address, sha256(Buffer.from('Borrower')), true);
@@ -360,10 +361,10 @@ describe('Pool With Compound Strategy', async () => {
     }
 
     describe('Check ratios', async () => {
-        async function lenderLendsTokens(amount: BigNumberish, fromSavingsAccount = false): Promise<void> {
+        async function lenderLendsTokens(amount: BigNumberish, strategy = zeroAddress): Promise<void> {
             await DaiTokenContract.connect(admin).transfer(lender.address, amount);
             await DaiTokenContract.connect(lender).approve(pool.address, amount);
-            await pool.connect(lender).lend(lender.address, amount, fromSavingsAccount);
+            await pool.connect(lender).lend(lender.address, amount, strategy);
             return;
         }
 
@@ -429,7 +430,7 @@ describe('Pool With Compound Strategy', async () => {
             await createPool();
             await DaiTokenContract.connect(admin).transfer(lender.address, _minborrowAmount);
             await DaiTokenContract.connect(lender).approve(pool.address, _minborrowAmount);
-            await pool.connect(lender).lend(lender.address, _minborrowAmount, false);
+            await pool.connect(lender).lend(lender.address, _minborrowAmount, zeroAddress);
         });
 
         it('Increase time by one day and check interest and total Debt', async () => {

--- a/test/PoolSimulations/poolWithNOStrategy_UNI_WBTC.ts
+++ b/test/PoolSimulations/poolWithNOStrategy_UNI_WBTC.ts
@@ -20,6 +20,7 @@ import {
     OperationalAmounts,
     extensionParams,
     repaymentParams,
+    verificationParams,
 } from '../../utils/constants';
 import DeployHelper from '../../utils/deploys';
 
@@ -225,7 +226,7 @@ describe('Pool using NO Strategy with UNI as borrow token and WBTC as collateral
         adminVerifierLogic = await deployHelper.helper.deployAdminVerifier();
         let adminVerificationProxy = await deployHelper.helper.deploySublimeProxy(adminVerifierLogic.address, proxyAdmin.address);
         adminVerifier = await deployHelper.helper.getAdminVerifier(adminVerificationProxy.address);
-        await verification.connect(admin).initialize(admin.address);
+        await verification.connect(admin).initialize(admin.address, verificationParams.activationDelay);
         await adminVerifier.connect(admin).initialize(admin.address, verification.address);
         await verification.connect(admin).addVerifier(adminVerifier.address);
         await adminVerifier.connect(admin).registerUser(borrower.address, sha256(Buffer.from('Borrower')), true);
@@ -372,10 +373,10 @@ describe('Pool using NO Strategy with UNI as borrow token and WBTC as collateral
     }
 
     describe('Check ratios', async () => {
-        async function lenderLendsTokens(amount: BigNumberish, fromSavingsAccount = false): Promise<void> {
+        async function lenderLendsTokens(amount: BigNumberish, strategy = zeroAddress): Promise<void> {
             await UNITokenContract.connect(admin).transfer(lender.address, amount);
             await UNITokenContract.connect(lender).approve(pool.address, amount);
-            await pool.connect(lender).lend(lender.address, amount, fromSavingsAccount);
+            await pool.connect(lender).lend(lender.address, amount, strategy);
             return;
         }
 
@@ -443,7 +444,7 @@ describe('Pool using NO Strategy with UNI as borrow token and WBTC as collateral
             await createPool();
             await UNITokenContract.connect(admin).transfer(lender.address, _minborrowAmount);
             await UNITokenContract.connect(lender).approve(pool.address, _minborrowAmount);
-            await pool.connect(lender).lend(lender.address, _minborrowAmount, false);
+            await pool.connect(lender).lend(lender.address, _minborrowAmount, zeroAddress);
         });
 
         it('Increase time by one day and check interest and total Debt', async () => {

--- a/utils/TestTemplate/Compound_poolLoanStages.ts
+++ b/utils/TestTemplate/Compound_poolLoanStages.ts
@@ -9,6 +9,7 @@ import {
     PoolFactoryInitParams,
     PriceOracleSource,
     RepaymentsInitParams,
+    VerificationParams,
     YearnPair,
 } from '../types';
 import hre from 'hardhat';
@@ -23,6 +24,7 @@ import {
     createPoolParams,
     zeroAddress,
     ChainLinkAggregators,
+    verificationParams,
 } from '../constants';
 
 import DeployHelper from '../deploys';
@@ -109,7 +111,10 @@ export async function compoundPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
@@ -255,7 +260,7 @@ export async function compoundPoolCollectionStage(
             await env.mockTokenContracts[0].contract.connect(admin).transfer(lender.address, amount);
             await env.mockTokenContracts[0].contract.connect(lender).approve(poolAddress, amount);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -292,7 +297,7 @@ export async function compoundPoolCollectionStage(
                 .deposit(amount, env.mockTokenContracts[0].contract.address, env.yields.noYield.address, lender.address);
             await env.savingsAccount.connect(lender).approve(amount, env.mockTokenContracts[0].contract.address, pool.address);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, true));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, env.yields.noYield.address));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -330,7 +335,7 @@ export async function compoundPoolCollectionStage(
                 .deposit(amount, env.mockTokenContracts[0].contract.address, env.yields.noYield.address, lender1.address);
             await env.savingsAccount.connect(lender1).approve(amount, env.mockTokenContracts[0].contract.address, pool.address);
 
-            const lendExpect = expect(pool.connect(lender1).lend(lender.address, amount, true));
+            const lendExpect = expect(pool.connect(lender1).lend(lender.address, amount, env.yields.noYield.address));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -359,7 +364,7 @@ export async function compoundPoolCollectionStage(
             await env.mockTokenContracts[0].contract.connect(admin).transfer(lender.address, amountLend);
             await env.mockTokenContracts[0].contract.connect(lender).approve(poolAddress, amountLend);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amountLend, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amountLend, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amountLend, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amountLend);
 
@@ -429,7 +434,10 @@ export async function compoundPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from('borrower' + Math.random() * 10000000));
@@ -495,7 +503,7 @@ export async function compoundPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -505,7 +513,7 @@ export async function compoundPoolCollectionStage(
             await borrowToken.connect(lender1).approve(poolAddress, amount1);
 
             // Lender1 lends into the pool
-            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, false));
+            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, zeroAddress));
             await lendExpect1.to.emit(pool, 'LiquiditySupplied').withArgs(amount1, lender1.address);
             await lendExpect1.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender1.address, amount1);
         });
@@ -727,7 +735,10 @@ export async function compoundPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from('borrower' + Math.random() * 10000000));
@@ -786,7 +797,7 @@ export async function compoundPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             // await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1206,7 +1217,10 @@ export async function compoundPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from('borrower' + Math.random() * 10000000));
@@ -1272,7 +1286,7 @@ export async function compoundPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1282,7 +1296,7 @@ export async function compoundPoolCollectionStage(
             await borrowToken.connect(lender1).approve(poolAddress, amount1);
 
             // Lender1 lends into the pool
-            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, false));
+            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, zeroAddress));
             await lendExpect1.to.emit(pool, 'LiquiditySupplied').withArgs(amount1, lender1.address);
             await lendExpect1.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender1.address, amount1);
 
@@ -1388,7 +1402,7 @@ export async function compoundPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1543,7 +1557,10 @@ export async function compoundPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
@@ -1613,7 +1630,7 @@ export async function compoundPoolCollectionStage(
             const borrowTokenBalancebefore = await Borrow.balanceOf(lender.address);
             const borrowTokenBalancePool = await Borrow.balanceOf(pool.address);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1718,7 +1735,10 @@ export async function compoundPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
@@ -1782,7 +1802,7 @@ export async function compoundPoolCollectionStage(
             await env.mockTokenContracts[0].contract.connect(admin).transfer(lender.address, amount);
             await env.mockTokenContracts[0].contract.connect(lender).approve(poolAddress, amount);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 

--- a/utils/TestTemplate/TestCase_1.ts
+++ b/utils/TestTemplate/TestCase_1.ts
@@ -9,6 +9,7 @@ import {
     PoolFactoryInitParams,
     PriceOracleSource,
     RepaymentsInitParams,
+    VerificationParams,
     YearnPair,
 } from '../types';
 import hre from 'hardhat';
@@ -25,6 +26,8 @@ import {
     testPoolFactoryParams,
 } from '../constants-Additions';
 
+import {} from "../constants";
+
 import DeployHelper from '../deploys';
 import { ERC20 } from '../../typechain/ERC20';
 import { sha256 } from '@ethersproject/sha2';
@@ -33,6 +36,7 @@ import { IYield } from '@typechain/IYield';
 import { Context } from 'mocha';
 import { Address } from 'hardhat-deploy/dist/types';
 import { Pool } from '@typechain/Pool';
+import { zeroAddress } from '../constants';
 
 export async function TestCase(
     BorrowToken: Address,
@@ -86,7 +90,10 @@ export async function TestCase(
                     protocolFeeCollector: '',
                 } as PoolFactoryInitParams,
                 CreditLineDefaultStrategy.Compound,
-                { _protocolFeeFraction: testPoolFactoryParams._protocolFeeFraction } as CreditLineInitParams
+                { _protocolFeeFraction: testPoolFactoryParams._protocolFeeFraction } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
@@ -201,7 +208,7 @@ export async function TestCase(
                 .connect(lender)
                 .approve(poolAddress, BigNumber.from(10).mul(BigNumber.from(10).pow(CTDecimals)));
 
-            await expect(pool.connect(lender).lend(lender.address, BigNumber.from(10).mul(BigNumber.from(10).pow(CTDecimals)), false))
+            await expect(pool.connect(lender).lend(lender.address, BigNumber.from(10).mul(BigNumber.from(10).pow(CTDecimals)), zeroAddress))
                 .to.emit(pool, 'LiquiditySupplied')
                 .withArgs(BigNumber.from(10).mul(BigNumber.from(10).pow(CTDecimals)), lender.address);
         });

--- a/utils/TestTemplate/Yearn_poolLoanStages.ts
+++ b/utils/TestTemplate/Yearn_poolLoanStages.ts
@@ -9,6 +9,7 @@ import {
     PoolFactoryInitParams,
     PriceOracleSource,
     RepaymentsInitParams,
+    VerificationParams,
     YearnPair,
 } from '../types';
 import hre from 'hardhat';
@@ -23,6 +24,7 @@ import {
     createPoolParams,
     zeroAddress,
     ChainLinkAggregators,
+    verificationParams,
 } from '../constants';
 
 import DeployHelper from '../deploys';
@@ -98,7 +100,10 @@ export async function yearnPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
@@ -244,7 +249,7 @@ export async function yearnPoolCollectionStage(
             await env.mockTokenContracts[0].contract.connect(admin).transfer(lender.address, amount);
             await env.mockTokenContracts[0].contract.connect(lender).approve(poolAddress, amount);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -281,7 +286,7 @@ export async function yearnPoolCollectionStage(
                 .deposit(amount, env.mockTokenContracts[0].contract.address, env.yields.noYield.address, lender.address);
             await env.savingsAccount.connect(lender).approve(amount, env.mockTokenContracts[0].contract.address, pool.address);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, true));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, env.yields.noYield.address));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -319,7 +324,7 @@ export async function yearnPoolCollectionStage(
                 .deposit(amount, env.mockTokenContracts[0].contract.address, env.yields.noYield.address, lender1.address);
             await env.savingsAccount.connect(lender1).approve(amount, env.mockTokenContracts[0].contract.address, pool.address);
 
-            const lendExpect = expect(pool.connect(lender1).lend(lender.address, amount, true));
+            const lendExpect = expect(pool.connect(lender1).lend(lender.address, amount, env.yields.noYield.address));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -348,7 +353,7 @@ export async function yearnPoolCollectionStage(
             await env.mockTokenContracts[0].contract.connect(admin).transfer(lender.address, amountLend);
             await env.mockTokenContracts[0].contract.connect(lender).approve(poolAddress, amountLend);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amountLend, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amountLend, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amountLend, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amountLend);
 
@@ -418,7 +423,10 @@ export async function yearnPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from('borrower' + Math.random() * 10000000));
@@ -484,7 +492,7 @@ export async function yearnPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -494,7 +502,7 @@ export async function yearnPoolCollectionStage(
             await borrowToken.connect(lender1).approve(poolAddress, amount1);
 
             // Lender1 lends into the pool
-            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, false));
+            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, zeroAddress));
             await lendExpect1.to.emit(pool, 'LiquiditySupplied').withArgs(amount1, lender1.address);
             await lendExpect1.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender1.address, amount1);
         });
@@ -716,7 +724,10 @@ export async function yearnPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from('borrower' + Math.random() * 10000000));
@@ -775,7 +786,7 @@ export async function yearnPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             // await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1194,7 +1205,10 @@ export async function yearnPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from('borrower' + Math.random() * 10000000));
@@ -1260,7 +1274,7 @@ export async function yearnPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1270,7 +1284,7 @@ export async function yearnPoolCollectionStage(
             await borrowToken.connect(lender1).approve(poolAddress, amount1);
 
             // Lender1 lends into the pool
-            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, false));
+            const lendExpect1 = expect(pool.connect(lender1).lend(lender1.address, amount1, zeroAddress));
             await lendExpect1.to.emit(pool, 'LiquiditySupplied').withArgs(amount1, lender1.address);
             await lendExpect1.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender1.address, amount1);
 
@@ -1380,7 +1394,7 @@ export async function yearnPoolCollectionStage(
             await borrowToken.connect(lender).approve(poolAddress, amount);
 
             // Lender lends into the pool
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1535,7 +1549,10 @@ export async function yearnPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
@@ -1605,7 +1622,7 @@ export async function yearnPoolCollectionStage(
             const borrowTokenBalancebefore = await Borrow.balanceOf(lender.address);
             const borrowTokenBalancePool = await Borrow.balanceOf(pool.address);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 
@@ -1710,7 +1727,10 @@ export async function yearnPoolCollectionStage(
                 {
                     _protocolFeeFraction: creditLineFactoryParams._protocolFeeFraction,
                     _liquidatorRewardFraction: creditLineFactoryParams._liquidatorRewardFraction,
-                } as CreditLineInitParams
+                } as CreditLineInitParams,
+                {
+                    activationDelay: verificationParams.activationDelay
+                } as VerificationParams,
             );
 
             let salt = sha256(Buffer.from(`borrower-${new Date().valueOf()}`));
@@ -1774,7 +1794,7 @@ export async function yearnPoolCollectionStage(
             await env.mockTokenContracts[0].contract.connect(admin).transfer(lender.address, amount);
             await env.mockTokenContracts[0].contract.connect(lender).approve(poolAddress, amount);
 
-            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, false));
+            const lendExpect = expect(pool.connect(lender).lend(lender.address, amount, zeroAddress));
             await lendExpect.to.emit(pool, 'LiquiditySupplied').withArgs(amount, lender.address);
             await lendExpect.to.emit(pool, 'Transfer').withArgs(zeroAddress, lender.address, amount);
 


### PR DESCRIPTION
## Description

Pool contract extends ERC20PausableUpgradeable which uses as default 18 decimals. The amount of pool tokens minted corresponds to the amount of the borrow asset lent to the pool. In other words, the Pool contract ignores the decimals of the borrow asset and for 1 Wei of borrow token sent to the pool, it mints 1 Wei of the pool token, despite the borrow asset might have different decimals. Although the accounting works for the contract, integrating with external components, e.g., UI, is prone to errors.

## Change Log

The decimals of the PoolToken have been shifted from the default 18 to the decimals of the borrowToken. Relevant changes were made to the tests.

## Function signature changes

`Pool:lend` function's signature was changed.
Earlier:
```
    function lend(
        address _lender,
        uint256 _amount,
        bool _fromSavingsAccount
    ) external payable nonReentrant {
```

Now
```
    function lend(
        address _lender,
        uint256 _amount,
        address _strategy
    ) external payable nonReentrant {
```

