### PR TITLE
Track Retired strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ test.spec.ts
 node_modules
 .env
 gasReport.md
+
+out
+out/*
+
+lib
+lib/*

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -152,7 +152,9 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         uint256 _amount
     ) external override nonReentrant {
         require(_currentStrategy != _newStrategy, 'SavingsAccount::switchStrategy Same strategy');
-        require(IStrategyRegistry(strategyRegistry).registry(_newStrategy), 'SavingsAccount::_newStrategy do not exist');
+        IStrategyRegistry _registry = IStrategyRegistry(strategyRegistry);
+        require(_registry.registry(_newStrategy), 'SavingsAccount::_newStrategy do not exist');
+        require(_registry.wasStrategy(_currentStrategy), 'SavingsAccount::_currentStrategy do not exist');
         require(_amount != 0, 'SavingsAccount::switchStrategy Amount must be greater than zero');
 
         IYield currentStrategy = IYield(_currentStrategy);

--- a/contracts/SavingsAccount/SavingsAccount.sol
+++ b/contracts/SavingsAccount/SavingsAccount.sol
@@ -112,29 +112,11 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         uint256 _amount
     ) external override nonReentrant returns (uint256) {
         require(_to != address(0), 'SavingsAccount::deposit receiver address should not be zero address');
-        uint256 _sharesReceived = _deposit(_token, _strategy, _amount);
-        balanceInShares[_to][_token][_strategy] = balanceInShares[_to][_token][_strategy].add(_sharesReceived);
-        emit Deposited(_to, _sharesReceived, _token, _strategy);
-        return _sharesReceived;
-    }
-
-    function _deposit(
-        address _token,
-        address _strategy,
-        uint256 _amount
-    ) internal returns (uint256) {
         require(_amount != 0, 'SavingsAccount::_deposit Amount must be greater than zero');
-        uint256 _sharesReceived = _depositToYield(_token, _strategy, _amount);
-        return _sharesReceived;
-    }
-
-    function _depositToYield(
-        address _token,
-        address _strategy,
-        uint256 _amount
-    ) internal returns (uint256) {
         require(IStrategyRegistry(strategyRegistry).registry(_strategy), 'SavingsAccount::deposit strategy do not exist');
         uint256 _sharesReceived = IYield(_strategy).lockTokens(msg.sender, _token, _amount);
+        balanceInShares[_to][_token][_strategy] = balanceInShares[_to][_token][_strategy].add(_sharesReceived);
+        emit Deposited(_to, _sharesReceived, _token, _strategy);
         return _sharesReceived;
     }
 
@@ -154,7 +136,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         require(_currentStrategy != _newStrategy, 'SavingsAccount::switchStrategy Same strategy');
         IStrategyRegistry _registry = IStrategyRegistry(strategyRegistry);
         require(_registry.registry(_newStrategy), 'SavingsAccount::_newStrategy do not exist');
-        require(_registry.wasStrategy(_currentStrategy), 'SavingsAccount::_currentStrategy do not exist');
+        require(_registry.isValidStrategy(_currentStrategy), 'SavingsAccount::_currentStrategy do not exist');
         require(_amount != 0, 'SavingsAccount::switchStrategy Amount must be greater than zero');
 
         IYield currentStrategy = IYield(_currentStrategy);
@@ -191,6 +173,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         bool _withdrawShares
     ) external override nonReentrant returns (uint256) {
         require(_amount != 0, 'SavingsAccount::withdraw Amount must be greater than zero');
+        require(IStrategyRegistry(strategyRegistry).isValidStrategy(_strategy), 'SavingsAccount::_currentStrategy do not exist');
 
         _amount = IYield(_strategy).getSharesForTokens(_amount, _token);
 
@@ -224,6 +207,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
         bool _withdrawShares
     ) external override nonReentrant returns (uint256) {
         require(_amount != 0, 'SavingsAccount::withdrawFrom Amount must be greater than zero');
+        require(IStrategyRegistry(strategyRegistry).isValidStrategy(_strategy), 'SavingsAccount::_currentStrategy do not exist');
 
         allowance[_from][_token][msg.sender] = allowance[_from][_token][msg.sender].sub(
             _amount,
@@ -297,6 +281,7 @@ contract SavingsAccount is ISavingsAccount, Initializable, OwnableUpgradeable, R
     }
 
     function withdrawAll(address _token, address _strategy) external override nonReentrant returns (uint256) {
+        require(IStrategyRegistry(strategyRegistry).isValidStrategy(_strategy), 'SavingsAccount::_currentStrategy do not exist');
         uint256 _sharesBalance = balanceInShares[msg.sender][_token][_strategy];
 
         if (_sharesBalance == 0) return 0;

--- a/contracts/interfaces/IStrategyRegistry.sol
+++ b/contracts/interfaces/IStrategyRegistry.sol
@@ -22,7 +22,7 @@ interface IStrategyRegistry {
 
     function registry(address strategy) external view returns (bool isValidStrategy);
 
-    function wasStrategy(address strategy) external view returns(bool wasValidStrategy);
+    function isValidStrategy(address strategy) external view returns(bool wasValidStrategy);
 
     function getStrategies() external view returns (address[] memory strategies);
 

--- a/contracts/interfaces/IStrategyRegistry.sol
+++ b/contracts/interfaces/IStrategyRegistry.sol
@@ -20,21 +20,23 @@ interface IStrategyRegistry {
      */
     event MaxStrategiesUpdated(uint256 maxStrategies);
 
-    function registry(address _strategy) external view returns (bool isValidStrategy);
+    function registry(address strategy) external view returns (bool isValidStrategy);
+
+    function wasStrategy(address strategy) external view returns(bool wasValidStrategy);
 
     function getStrategies() external view returns (address[] memory strategies);
 
     /**
      * @dev Add strategies to invest in. Please ensure that number of strategies are less than maxStrategies.
-     * @param _strategy address of the owner of the savings account contract
+     * @param strategy address of the owner of the savings account contract
      **/
-    function addStrategy(address _strategy) external;
+    function addStrategy(address strategy) external;
 
     /**
      * @dev Remove strategy to invest in.
-     * @param _strategyIndex Index of the strategy to remove
+     * @param strategyIndex Index of the strategy to remove
      **/
-    function removeStrategy(uint256 _strategyIndex) external;
+    function removeStrategy(uint256 strategyIndex) external;
 
     /**
      * @dev Update strategy to invest in.

--- a/contracts/interfaces/IStrategyRegistry.sol
+++ b/contracts/interfaces/IStrategyRegistry.sol
@@ -20,9 +20,9 @@ interface IStrategyRegistry {
      */
     event MaxStrategiesUpdated(uint256 maxStrategies);
 
-    function registry(address strategy) external view returns (bool isValidStrategy);
+    function registry(address strategy) external view returns (bool isActiveStrategy);
 
-    function isValidStrategy(address strategy) external view returns(bool wasValidStrategy);
+    function isValidStrategy(address strategy) external view returns(bool validStrategy);
 
     function getStrategies() external view returns (address[] memory strategies);
 

--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -85,7 +85,10 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
      **/
     function removeStrategy(uint256 _strategyIndex) external override onlyOwner {
         address _strategy = strategies[_strategyIndex];
-        strategies[_strategyIndex] = strategies[strategies.length.sub(1, 'StrategyRegistry::removeStrategy - No strategies exist')];
+        address[] _strategies = strategies;
+        for(uint256 i = _strategyIndex; i < _strategies.length-1; ++i) {
+            strategies[i] = _strategies[i+1];
+        }
         strategies.pop();
         delete registry[_strategy];
         retiredRegistry[_strategy] = true;

--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -25,6 +25,11 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
     mapping(address => bool) public override registry;
 
     /**
+     * @notice registry which maps retired strategies which were once whitelisted to true
+     **/
+    mapping(address => bool) public override retiredRegistry;
+
+    /**
      * @notice used to initialize the paramters of strategy registry
      * @dev can only be called once
      * @param _owner address of the owner
@@ -83,6 +88,7 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
         strategies[_strategyIndex] = strategies[strategies.length.sub(1, 'StrategyRegistry::removeStrategy - No strategies exist')];
         strategies.pop();
         delete registry[_strategy];
+        retiredRegistry[_strategy] = true;
 
         emit StrategyRemoved(_strategy);
     }
@@ -108,8 +114,13 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
         strategies[_strategyIndex] = _newStrategy;
 
         delete registry[_oldStrategy];
+        retiredRegistry[_oldStrategy] = true;
         emit StrategyRemoved(_oldStrategy);
         registry[_newStrategy] = true;
         emit StrategyAdded(_newStrategy);
+    }
+
+    function wasStrategy(address _strategy) external view override {
+        return (registry[_strategy] || retiredRegistry[_strategy]);
     }
 }

--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -85,7 +85,7 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
      **/
     function removeStrategy(uint256 _strategyIndex) external override onlyOwner {
         address _strategy = strategies[_strategyIndex];
-        address[] _strategies = strategies;
+        address[] memory _strategies = strategies;
         for(uint256 i = _strategyIndex; i < _strategies.length-1; ++i) {
             strategies[i] = _strategies[i+1];
         }

--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -120,7 +120,7 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
         emit StrategyAdded(_newStrategy);
     }
 
-    function wasStrategy(address _strategy) external view override returns(bool) {
+    function isValidStrategy(address _strategy) external view override returns(bool) {
         return (registry[_strategy] || retiredRegistry[_strategy]);
     }
 }

--- a/contracts/yield/StrategyRegistry.sol
+++ b/contracts/yield/StrategyRegistry.sol
@@ -27,7 +27,7 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
     /**
      * @notice registry which maps retired strategies which were once whitelisted to true
      **/
-    mapping(address => bool) public override retiredRegistry;
+    mapping(address => bool) public retiredRegistry;
 
     /**
      * @notice used to initialize the paramters of strategy registry
@@ -120,7 +120,7 @@ contract StrategyRegistry is Initializable, OwnableUpgradeable, IStrategyRegistr
         emit StrategyAdded(_newStrategy);
     }
 
-    function wasStrategy(address _strategy) external view override {
+    function wasStrategy(address _strategy) external view override returns(bool) {
         return (registry[_strategy] || retiredRegistry[_strategy]);
     }
 }


### PR DESCRIPTION
Strategy registry tracks the strategies which are removed to ensure that they can still be withdrawn from even after retiring.